### PR TITLE
Fix/Copying tensor

### DIFF
--- a/lettucedetect/models/inference.py
+++ b/lettucedetect/models/inference.py
@@ -88,7 +88,7 @@ class TransformerDetector(BaseDetector):
             for key, value in encoding.items()
             if key in ["input_ids", "attention_mask", "labels"]
         }
-        labels = torch.tensor(labels, device=self.device)
+        labels = labels.clone().detach().to(self.device)
 
         # Run model inference
         with torch.no_grad():

--- a/lettucedetect/models/inference.py
+++ b/lettucedetect/models/inference.py
@@ -88,7 +88,6 @@ class TransformerDetector(BaseDetector):
             for key, value in encoding.items()
             if key in ["input_ids", "attention_mask", "labels"]
         }
-        labels = labels.clone().detach().to(self.device)
 
         # Run model inference
         with torch.no_grad():


### PR DESCRIPTION
**Misbehaviour**
After installing the package via `pip install -e .` on a clean python environment and running the notebook `detection.ipynb`, I get the following UserWarning `/Users/kovacs/projects/LettuceDetect/lettucedetect/models/inference.py:84: UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).
  labels = torch.tensor(labels, device=self.device)`

First I improved this line of code ` labels = torch.tensor(labels, device=self.device)`
as suggested but finally removed the line since I did not understand the reason to copy a tensor into the same tensor variable again, seen [here](https://github.com/KRLabsOrg/LettuceDetect/blob/45793eb7248e04c5570b83cb28716be09edc965d/lettucedetect/models/inference.py#L91C8-L92C1).