### PR TITLE
Add cascade detector infrastructure

### DIFF
--- a/lettucedetect/__init__.py
+++ b/lettucedetect/__init__.py
@@ -15,13 +15,48 @@ from lettucedetect.models.inference import HallucinationDetector
 # Direct RAGFactChecker access for advanced users
 from lettucedetect.ragfactchecker import RAGFactChecker
 
+# Cascade configuration
+from lettucedetect.configs import (
+    CascadeConfig,
+    RoutingConfig,
+    Stage1Config,
+    Stage2Config,
+    Stage3Config,
+    Stage3Method,
+    FAST_CASCADE,
+    FULL_CASCADE,
+    PRESETS,
+    STAGE1_AUGMENTED,
+    STAGE1_MINIMAL,
+    STAGE2_ONLY,
+    STAGE3_SELF_CONSISTENCY,
+    STAGE3_SEPS,
+)
+
 __version__ = "0.1.7"
 
 __all__ = [
+    # Existing
     "HallucinationData",
     "HallucinationDataset",
     "HallucinationDetector",
     "HallucinationGenerator",
     "HallucinationSample",
-    "RAGFactChecker",  # Direct access to triplet functionality
+    "RAGFactChecker",
+    # Configs
+    "CascadeConfig",
+    "Stage1Config",
+    "Stage2Config",
+    "Stage3Config",
+    "RoutingConfig",
+    "Stage3Method",
+    # Presets
+    "FULL_CASCADE",
+    "FAST_CASCADE",
+    "STAGE1_AUGMENTED",
+    "STAGE1_MINIMAL",
+    "STAGE2_ONLY",
+    "STAGE3_SEPS",
+    "STAGE3_SELF_CONSISTENCY",
+    "PRESETS",
 ]

--- a/lettucedetect/cascade/__init__.py
+++ b/lettucedetect/cascade/__init__.py
@@ -1,0 +1,17 @@
+"""Cascade detector types and base classes."""
+
+from lettucedetect.cascade.types import (
+    AugmentationResult,
+    BaseStage,
+    CascadeInput,
+    RoutingDecision,
+    StageResult,
+)
+
+__all__ = [
+    "RoutingDecision",
+    "StageResult",
+    "CascadeInput",
+    "AugmentationResult",
+    "BaseStage",
+]

--- a/lettucedetect/cascade/types.py
+++ b/lettucedetect/cascade/types.py
@@ -1,0 +1,83 @@
+"""Core types for cascade detector stages."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import Enum
+
+
+class RoutingDecision(Enum):
+    """Routing decision after a stage completes."""
+
+    RETURN_CONFIDENT = "return_confident"
+    ESCALATE = "escalate"
+    RETURN_UNCERTAIN = "return_uncertain"
+
+
+@dataclass
+class StageResult:
+    """Result from a single stage in the cascade."""
+
+    stage_name: str
+    confidence: float
+    is_hallucination: bool
+    routing_decision: RoutingDecision
+    latency_ms: float
+    output_format_result: list[dict]
+    metadata: dict
+
+
+@dataclass
+class CascadeInput:
+    """Input to a cascade stage."""
+
+    context: list[str]
+    answer: str
+    question: str | None = None
+    prompt: str | None = None
+    previous_stage_result: StageResult | None = None
+
+
+@dataclass
+class AugmentationResult:
+    """Result from a Stage 1 augmentation.
+
+    Defined here to avoid circular imports between utils/ and detectors/.
+    """
+
+    score: float  # 0.0 = hallucination, 1.0 = supported
+    confidence: float  # Confidence in this score
+    details: dict  # Component-specific details
+    flagged_spans: list[dict]  # Spans flagged by this augmentation
+
+
+class BaseStage(ABC):
+    """Abstract base class for cascade stage detectors.
+
+    Each stage must implement run() to process CascadeInput and return StageResult.
+    """
+
+    @abstractmethod
+    def run(
+        self,
+        input: CascadeInput,
+        output_format: str = "tokens",
+        has_next_stage: bool = True,
+    ) -> StageResult:
+        """Process input and return stage result with routing decision.
+
+        Args:
+            input: CascadeInput with context, answer, and optional previous result
+            output_format: Output format ("tokens" or "spans")
+            has_next_stage: Whether there's a subsequent stage (affects routing)
+
+        Returns:
+            StageResult with confidence, prediction, and routing decision
+        """
+        pass
+
+    @abstractmethod
+    def warmup(self) -> None:
+        """Warmup models for consistent latency."""
+        pass

--- a/lettucedetect/configs/__init__.py
+++ b/lettucedetect/configs/__init__.py
@@ -1,0 +1,39 @@
+"""Configuration models and presets for cascade detector."""
+
+from lettucedetect.configs.models import (
+    CascadeConfig,
+    RoutingConfig,
+    Stage1Config,
+    Stage2Config,
+    Stage3Config,
+    Stage3Method,
+)
+from lettucedetect.configs.presets import (
+    FAST_CASCADE,
+    FULL_CASCADE,
+    PRESETS,
+    STAGE1_AUGMENTED,
+    STAGE1_MINIMAL,
+    STAGE2_ONLY,
+    STAGE3_SELF_CONSISTENCY,
+    STAGE3_SEPS,
+)
+
+__all__ = [
+    # Models
+    "CascadeConfig",
+    "Stage1Config",
+    "Stage2Config",
+    "Stage3Config",
+    "RoutingConfig",
+    "Stage3Method",
+    # Presets
+    "FULL_CASCADE",
+    "FAST_CASCADE",
+    "STAGE1_AUGMENTED",
+    "STAGE1_MINIMAL",
+    "STAGE2_ONLY",
+    "STAGE3_SEPS",
+    "STAGE3_SELF_CONSISTENCY",
+    "PRESETS",
+]

--- a/lettucedetect/configs/models.py
+++ b/lettucedetect/configs/models.py
@@ -1,0 +1,105 @@
+"""Pydantic configuration models for cascade detector."""
+
+from __future__ import annotations
+
+import json
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class Stage3Method(str, Enum):
+    """Available methods for Stage 3 detection."""
+
+    SEPS = "seps"
+    SELF_CONSISTENCY = "self_consistency"
+    SEMANTIC_ENTROPY = "semantic_entropy"
+
+
+class Stage1Config(BaseModel):
+    """Configuration for Stage 1: Transformer + Augmentations."""
+
+    model_path: str = "KRLabsOrg/lettucedect-base-modernbert-en-v1"
+    augmentations: list[Literal["ner", "numeric", "lexical"]] = []
+    weights: dict[str, float] = Field(
+        default_factory=lambda: {
+            "transformer": 0.5,
+            "ner": 0.2,
+            "numeric": 0.15,
+            "lexical": 0.15,
+        }
+    )
+    max_length: int = 4096
+    device: str = "cuda"
+    lang: str = "en"
+
+
+class Stage2Config(BaseModel):
+    """Configuration for Stage 2: NCS + NLI + Lexical."""
+
+    components: list[Literal["ncs", "nli", "lexical"]] = ["ncs", "nli", "lexical"]
+    ncs_model: str = "minishlab/potion-base-32M"
+    nli_model: str = "microsoft/deberta-v3-base-mnli"
+    weights: dict[str, float] = Field(
+        default_factory=lambda: {"ncs": 0.4, "nli": 0.4, "lexical": 0.2}
+    )
+
+
+class Stage3Config(BaseModel):
+    """Configuration for Stage 3: SEPs / Self-Consistency / Semantic Entropy."""
+
+    method: Stage3Method = Stage3Method.SEPS
+
+    # SEPs config
+    llm_model: str = "meta-llama/Llama-3.2-3B"
+    probe_path: str | None = None
+    layer_index: int = -1
+    token_position: Literal["last", "mean"] = "last"
+    load_in_4bit: bool = False
+    load_in_8bit: bool = False
+
+    # Self-Consistency config
+    api_model: str = "gpt-4o-mini"
+    num_samples: int = 5
+    temperature: float = 0.7
+    consistency_method: Literal["bertscore", "nli", "hybrid"] = "hybrid"
+
+    # Semantic Entropy config
+    clustering_method: Literal["nli", "embedding"] = "nli"
+
+
+class RoutingConfig(BaseModel):
+    """Configuration for inter-stage routing decisions."""
+
+    threshold_1to2: float = 0.7
+    threshold_2to3: float = 0.7
+
+
+class CascadeConfig(BaseModel):
+    """Main configuration for cascade detector."""
+
+    stages: list[Literal[1, 2, 3]] = [1, 2, 3]
+    stage1: Stage1Config = Field(default_factory=Stage1Config)
+    stage2: Stage2Config = Field(default_factory=Stage2Config)
+    stage3: Stage3Config = Field(default_factory=Stage3Config)
+    routing: RoutingConfig = Field(default_factory=RoutingConfig)
+
+    @field_validator("stages")
+    @classmethod
+    def validate_stages_order(cls, v: list[int]) -> list[int]:
+        """Ensure stages are in ascending order."""
+        if v != sorted(v):
+            raise ValueError(f"Stages must be in ascending order, got {v}")
+        return v
+
+    @classmethod
+    def from_json(cls, path: str) -> CascadeConfig:
+        """Load config from JSON file."""
+        with open(path) as f:
+            return cls.model_validate(json.load(f))
+
+    def to_json(self, path: str) -> None:
+        """Save config to JSON file."""
+        with open(path, "w") as f:
+            json.dump(self.model_dump(), f, indent=2)

--- a/lettucedetect/configs/presets.py
+++ b/lettucedetect/configs/presets.py
@@ -1,0 +1,71 @@
+"""Preset configurations for common cascade use cases."""
+
+from lettucedetect.configs.models import (
+    CascadeConfig,
+    RoutingConfig,
+    Stage1Config,
+    Stage2Config,
+    Stage3Config,
+    Stage3Method,
+)
+
+# Full 3-stage cascade
+FULL_CASCADE = CascadeConfig(
+    stages=[1, 2, 3],
+    stage1=Stage1Config(augmentations=["ner", "numeric", "lexical"]),
+    stage2=Stage2Config(),
+    stage3=Stage3Config(method=Stage3Method.SEPS),
+    routing=RoutingConfig(threshold_1to2=0.7, threshold_2to3=0.7),
+)
+
+# Fast 2-stage cascade (no LLM calls)
+FAST_CASCADE = CascadeConfig(
+    stages=[1, 2],
+    stage1=Stage1Config(augmentations=["ner", "numeric", "lexical"]),
+    stage2=Stage2Config(),
+    routing=RoutingConfig(threshold_1to2=0.7),
+)
+
+# Stage 1 only with augmentations
+STAGE1_AUGMENTED = CascadeConfig(
+    stages=[1],
+    stage1=Stage1Config(augmentations=["ner", "numeric", "lexical"]),
+)
+
+# Stage 1 only, no augmentations (equivalent to legacy transformer)
+STAGE1_MINIMAL = CascadeConfig(
+    stages=[1],
+    stage1=Stage1Config(augmentations=[]),
+)
+
+# Stage 2 only (for comparison testing)
+STAGE2_ONLY = CascadeConfig(
+    stages=[2],
+    stage2=Stage2Config(),
+)
+
+# Stage 3 SEPs only
+STAGE3_SEPS = CascadeConfig(
+    stages=[3],
+    stage3=Stage3Config(method=Stage3Method.SEPS),
+)
+
+# Stage 3 Self-Consistency
+STAGE3_SELF_CONSISTENCY = CascadeConfig(
+    stages=[3],
+    stage3=Stage3Config(
+        method=Stage3Method.SELF_CONSISTENCY,
+        num_samples=5,
+    ),
+)
+
+# All presets dict for easy access
+PRESETS = {
+    "full_cascade": FULL_CASCADE,
+    "fast_cascade": FAST_CASCADE,
+    "stage1_augmented": STAGE1_AUGMENTED,
+    "stage1_minimal": STAGE1_MINIMAL,
+    "stage2_only": STAGE2_ONLY,
+    "stage3_seps": STAGE3_SEPS,
+    "stage3_self_consistency": STAGE3_SELF_CONSISTENCY,
+}

--- a/lettucedetect/detectors/cascade.py
+++ b/lettucedetect/detectors/cascade.py
@@ -1,0 +1,233 @@
+"""Cascade detector with latency-tiered stages."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from lettucedetect.cascade.types import CascadeInput, RoutingDecision, StageResult
+from lettucedetect.configs import CascadeConfig, Stage3Method
+from lettucedetect.detectors.base import BaseDetector
+
+logger = logging.getLogger(__name__)
+
+
+class CascadeDetector(BaseDetector):
+    """Cascade detector that routes through multiple stages.
+
+    Implements the latency-tiered cascade architecture:
+    - Stage 1: Fast detection (<30ms)
+    - Stage 2: Embedding analysis (<30ms)
+    - Stage 3: Uncertainty quantification (<100ms)
+
+    Routing decisions are made based on confidence thresholds.
+    """
+
+    def __init__(self, config: CascadeConfig) -> None:
+        """Initialize cascade detector with config."""
+        self.config = config
+        self._stages: dict = {}
+        self._initialize_stages()
+
+    def _initialize_stages(self) -> None:
+        """Initialize detector for each configured stage."""
+        for stage_num in self.config.stages:
+            if stage_num == 1:
+                self._stages[1] = self._init_stage1()
+            elif stage_num == 2:
+                self._stages[2] = self._init_stage2()
+            elif stage_num == 3:
+                self._stages[3] = self._init_stage3()
+
+    def _init_stage1(self):
+        """Initialize Stage 1 detector."""
+        from lettucedetect.detectors.stage1 import Stage1Detector
+
+        return Stage1Detector(config=self.config.stage1)
+
+    def _init_stage2(self):
+        """Initialize Stage 2 detector."""
+        from lettucedetect.detectors.stage2 import Stage2Detector
+
+        return Stage2Detector(config=self.config.stage2)
+
+    def _init_stage3(self):
+        """Initialize Stage 3 detector based on configured method."""
+        if self.config.stage3.method == Stage3Method.SEPS:
+            from lettucedetect.detectors.stage3.seps_detector import SEPsDetector
+
+            return SEPsDetector(
+                model_name_or_path=self.config.stage3.llm_model,
+                probe_path=self.config.stage3.probe_path,
+                layer_index=self.config.stage3.layer_index,
+                token_position=self.config.stage3.token_position,
+                load_in_8bit=self.config.stage3.load_in_8bit,
+                load_in_4bit=self.config.stage3.load_in_4bit,
+            )
+        elif self.config.stage3.method == Stage3Method.SELF_CONSISTENCY:
+            from lettucedetect.detectors.stage3.self_consistency_detector import (
+                SelfConsistencyDetector,
+            )
+
+            return SelfConsistencyDetector(
+                model=self.config.stage3.api_model,
+                num_samples=self.config.stage3.num_samples,
+                temperature=self.config.stage3.temperature,
+                consistency_method=self.config.stage3.consistency_method,
+            )
+        elif self.config.stage3.method == Stage3Method.SEMANTIC_ENTROPY:
+            from lettucedetect.detectors.stage3.semantic_entropy_detector import (
+                SemanticEntropyDetector,
+            )
+
+            return SemanticEntropyDetector(
+                model=self.config.stage3.api_model,
+                num_samples=self.config.stage3.num_samples,
+                clustering_method=self.config.stage3.clustering_method,
+            )
+        else:
+            raise ValueError(f"Unknown Stage 3 method: {self.config.stage3.method}")
+
+    def predict(
+        self,
+        context: list[str],
+        answer: str,
+        question: str | None = None,
+        output_format: str = "tokens",
+    ) -> list | dict:
+        """Main prediction - routes through cascade stages."""
+        start_time = time.perf_counter()
+
+        cascade_input = CascadeInput(
+            context=context,
+            answer=answer,
+            question=question,
+        )
+
+        stage_results = []
+        final_result = None
+
+        for stage_num in sorted(self.config.stages):
+            stage = self._stages.get(stage_num)
+            if stage is None:
+                continue
+
+            has_next_stage = stage_num < max(self.config.stages)
+            result = self._run_stage(
+                stage, stage_num, cascade_input, has_next_stage, output_format
+            )
+            stage_results.append(result)
+
+            if result.routing_decision == RoutingDecision.RETURN_CONFIDENT:
+                final_result = result
+                break
+            elif result.routing_decision == RoutingDecision.RETURN_UNCERTAIN:
+                final_result = result
+                break
+            else:
+                cascade_input.previous_stage_result = result
+
+        if final_result is None and stage_results:
+            final_result = stage_results[-1]
+
+        total_latency = (time.perf_counter() - start_time) * 1000
+
+        if output_format == "detailed":
+            return self._format_detailed(final_result, stage_results, total_latency)
+        elif output_format == "spans":
+            return final_result.output_format_result if final_result else []
+        else:
+            return final_result.output_format_result if final_result else []
+
+    def _run_stage(
+        self,
+        stage,
+        stage_num: int,
+        cascade_input: CascadeInput,
+        has_next_stage: bool,
+        output_format: str = "tokens",
+    ) -> StageResult:
+        """Run a single stage and return result.
+
+        Args:
+            stage: The stage detector instance (implements BaseStage)
+            stage_num: Stage number (1, 2, or 3)
+            cascade_input: Input data for the stage
+            has_next_stage: Whether there's a subsequent stage (affects routing)
+            output_format: Output format ("tokens" or "spans")
+
+        Returns:
+            StageResult with confidence, prediction, and routing decision
+        """
+        stage_start = time.perf_counter()
+
+        # Run the stage detector
+        result = stage.run(
+            input=cascade_input,
+            output_format=output_format,
+            has_next_stage=has_next_stage,
+        )
+
+        # Calculate latency
+        latency_ms = (time.perf_counter() - stage_start) * 1000
+        result.latency_ms = latency_ms
+
+        logger.debug(
+            f"Stage {stage_num} completed in {latency_ms:.2f}ms, "
+            f"confidence={result.confidence:.3f}, "
+            f"routing={result.routing_decision.value}"
+        )
+
+        return result
+
+    def _format_detailed(
+        self,
+        final_result: StageResult | None,
+        stage_results: list[StageResult],
+        total_latency: float,
+    ) -> dict:
+        """Format detailed output with routing info."""
+        if final_result is None:
+            return {"spans": [], "routing": {}, "scores": {}}
+
+        return {
+            "spans": final_result.output_format_result,
+            "routing": {
+                "resolved_at_stage": int(final_result.stage_name[-1]),
+                "stages_executed": [int(r.stage_name[-1]) for r in stage_results],
+                "total_latency_ms": total_latency,
+                "stage_latencies_ms": {
+                    r.stage_name: r.latency_ms for r in stage_results
+                },
+            },
+            "scores": {
+                "final_score": final_result.confidence,
+                "confident": final_result.routing_decision
+                == RoutingDecision.RETURN_CONFIDENT,
+                "escalated": final_result.routing_decision == RoutingDecision.ESCALATE,
+                "per_stage": {
+                    r.stage_name: r.metadata.get("scores", {}) for r in stage_results
+                },
+            },
+        }
+
+    def predict_prompt(
+        self, prompt: str, answer: str, output_format: str = "tokens"
+    ) -> list | dict:
+        """Predict with pre-formatted prompt - implements BaseDetector interface."""
+        context = [prompt]
+        return self.predict(context, answer, question=None, output_format=output_format)
+
+    def predict_prompt_batch(
+        self, prompts: list[str], answers: list[str], output_format: str = "tokens"
+    ) -> list:
+        """Batch prediction with prompts - implements BaseDetector interface."""
+        return [
+            self.predict_prompt(p, a, output_format) for p, a in zip(prompts, answers)
+        ]
+
+    def warmup(self) -> None:
+        """Warmup all stage detectors."""
+        for stage in self._stages.values():
+            if stage is not None and hasattr(stage, "warmup"):
+                stage.warmup()

--- a/lettucedetect/detectors/factory.py
+++ b/lettucedetect/detectors/factory.py
@@ -2,20 +2,30 @@
 
 from __future__ import annotations
 
+import logging
+
 from lettucedetect.detectors.base import BaseDetector
 
 __all__ = ["make_detector"]
+
+logger = logging.getLogger(__name__)
 
 
 def make_detector(method: str, **kwargs) -> BaseDetector:
     """Create a detector of the requested type with the given parameters.
 
-    :param method: One of "transformer", "llm", or "rag_fact_checker".
+    :param method: One of "transformer", "llm", "rag_fact_checker", or "cascade".
     :param kwargs: Passed to the concrete detector constructor.
     :return: A concrete detector instance.
     :raises ValueError: If method is not supported.
     """
     if method == "transformer":
+        augmentations = kwargs.pop("augmentations", None)
+        if augmentations:
+            # Stage1Detector wraps TransformerDetector with augmentations
+            from lettucedetect.detectors.stage1 import Stage1Detector
+
+            return Stage1Detector(augmentations=augmentations, **kwargs)
         from lettucedetect.detectors.transformer import TransformerDetector
 
         return TransformerDetector(**kwargs)
@@ -27,7 +37,33 @@ def make_detector(method: str, **kwargs) -> BaseDetector:
         from lettucedetect.detectors.rag_fact_checker import RAGFactCheckerDetector
 
         return RAGFactCheckerDetector(**kwargs)
+    elif method == "cascade":
+        from lettucedetect.configs import CascadeConfig
+        from lettucedetect.detectors.cascade import CascadeDetector
+
+        config = kwargs.get("config")
+        config_path = kwargs.get("config_path")
+
+        if config_path:
+            config = CascadeConfig.from_json(config_path)
+            logger.info(f"Loaded cascade config from {config_path}")
+        elif isinstance(config, dict):
+            config = CascadeConfig.model_validate(config)
+        elif config is None:
+            raise ValueError(
+                "cascade method requires 'config' (CascadeConfig or dict) or 'config_path'"
+            )
+
+        # Log warning for missing stage configs
+        for stage_num in config.stages:
+            stage_key = f"stage{stage_num}"
+            stage_config = getattr(config, stage_key)
+            if stage_config == getattr(CascadeConfig(), stage_key):
+                logger.warning(f"No {stage_key} config provided, using defaults")
+
+        return CascadeDetector(config=config)
     else:
         raise ValueError(
-            f"Unknown detector method: {method}. Use one of: transformer, llm, rag_fact_checker"
+            f"Unknown detector method: {method}. "
+            f"Valid: transformer, llm, rag_fact_checker, cascade"
         )

--- a/lettucedetect/utils/__init__.py
+++ b/lettucedetect/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Shared utilities for cascade detector."""
+
+from lettucedetect.utils.lexical import LexicalOverlapCalculator
+
+__all__ = ["LexicalOverlapCalculator"]

--- a/lettucedetect/utils/lexical.py
+++ b/lettucedetect/utils/lexical.py
@@ -1,0 +1,125 @@
+"""Shared lexical overlap calculator for Stage 1 and Stage 2."""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+
+from lettucedetect.cascade.types import AugmentationResult
+
+
+@dataclass
+class LexicalConfig:
+    """Configuration for lexical overlap calculation."""
+
+    use_stemming: bool = True
+    remove_stopwords: bool = True
+    ngram_range: tuple[int, int] = (1, 2)
+    stopwords_lang: str = "english"
+
+
+class LexicalOverlapCalculator:
+    """Calculate lexical overlap between context and answer.
+
+    Used by both Stage 1 (augmentation) and Stage 2 (component).
+    """
+
+    def __init__(self, config: LexicalConfig | None = None) -> None:
+        """Initialize calculator with optional config."""
+        self.config = config or LexicalConfig()
+        self._stemmer = None
+        self._stopwords: set[str] | None = None
+
+        if self.config.use_stemming:
+            from nltk.stem import PorterStemmer
+
+            self._stemmer = PorterStemmer()
+
+        if self.config.remove_stopwords:
+            from nltk.corpus import stopwords
+
+            self._stopwords = set(stopwords.words(self.config.stopwords_lang))
+
+    def _tokenize(self, text: str) -> list[str]:
+        """Tokenize and optionally stem/filter text."""
+        tokens = re.findall(r"\b\w+\b", text.lower())
+
+        if self._stopwords:
+            tokens = [t for t in tokens if t not in self._stopwords]
+
+        if self._stemmer:
+            tokens = [self._stemmer.stem(t) for t in tokens]
+
+        return tokens
+
+    def _get_ngrams(self, tokens: list[str]) -> Counter:
+        """Extract n-grams from token list."""
+        ngrams: Counter = Counter()
+        min_n, max_n = self.config.ngram_range
+
+        for n in range(min_n, max_n + 1):
+            for i in range(len(tokens) - n + 1):
+                ngram = tuple(tokens[i : i + n])
+                ngrams[ngram] += 1
+
+        return ngrams
+
+    def compute_jaccard(self, context: list[str], answer: str) -> float:
+        """Compute Jaccard similarity between context and answer n-grams."""
+        context_text = " ".join(context)
+        context_tokens = self._tokenize(context_text)
+        answer_tokens = self._tokenize(answer)
+
+        context_ngrams = set(self._get_ngrams(context_tokens).keys())
+        answer_ngrams = set(self._get_ngrams(answer_tokens).keys())
+
+        if not answer_ngrams:
+            return 1.0  # No answer tokens = no hallucination possible
+
+        intersection = context_ngrams & answer_ngrams
+        union = context_ngrams | answer_ngrams
+
+        if not union:
+            return 0.0
+
+        return len(intersection) / len(union)
+
+    def compute_support_score(self, context: list[str], answer: str) -> float:
+        """Compute support score (0=unsupported, 1=fully supported)."""
+        return self.compute_jaccard(context, answer)
+
+    def score(
+        self,
+        context: list[str],
+        answer: str,
+        question: str | None = None,
+        token_predictions: list[dict] | None = None,
+    ) -> AugmentationResult:
+        """Score method for Stage 1 augmentation interface."""
+        overlap_score = self.compute_support_score(context, answer)
+
+        return AugmentationResult(
+            score=overlap_score,
+            confidence=0.8,
+            details={"jaccard": overlap_score},
+            flagged_spans=[],
+        )
+
+    @property
+    def name(self) -> str:
+        """Return augmentation name."""
+        return "lexical"
+
+    def preload(self) -> None:
+        """Preload NLTK resources."""
+        import nltk
+
+        try:
+            nltk.data.find("corpora/stopwords")
+        except LookupError:
+            nltk.download("stopwords", quiet=True)
+        try:
+            nltk.data.find("tokenizers/punkt")
+        except LookupError:
+            nltk.download("punkt", quiet=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "numpy>=2.2.2",
     "openai>=1.66.3",
     "rag-fact-checker",
+    "pydantic>=2.0.0",
 ]
 
 [project.urls]
@@ -35,12 +36,30 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.25",
+    "pytest-benchmark>=4.0.0",
     "ruff>=0.0.270",
 ]
 api = [
     "fastapi[standard]>=0.115",
     "pydantic-settings>=2.8.0",
     "httpx>=0.28"
+]
+stage1 = [
+    "spacy>=3.7.0",
+    "rapidfuzz>=3.0.0",
+    "nltk>=3.8.0",
+]
+stage2 = [
+    "model2vec>=0.3.0",
+]
+stage3 = [
+    "sentence-transformers>=2.2.0",
+    "bert-score>=0.3.13",
+    "bitsandbytes>=0.41.0",
+    "accelerate>=0.24.0",
+]
+cascade = [
+    "lettucedetect[stage1,stage2,stage3]",
 ]
 
 [tool.setuptools]

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for lettucedetect."""

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -1,0 +1,151 @@
+"""Unit tests for cascade configuration models."""
+
+import pytest
+
+# Import directly from submodules to avoid heavy imports from main __init__.py
+from lettucedetect.configs.models import (
+    CascadeConfig,
+    RoutingConfig,
+    Stage1Config,
+    Stage2Config,
+    Stage3Config,
+    Stage3Method,
+)
+from lettucedetect.configs.presets import (
+    FULL_CASCADE,
+    FAST_CASCADE,
+    STAGE1_AUGMENTED,
+    PRESETS,
+)
+
+
+class TestCascadeConfigDefaults:
+    """Test default configuration values."""
+
+    def test_cascade_config_defaults(self):
+        """CascadeConfig should have sensible defaults."""
+        config = CascadeConfig()
+        assert config.stages == [1, 2, 3]
+        assert isinstance(config.stage1, Stage1Config)
+        assert isinstance(config.stage2, Stage2Config)
+        assert isinstance(config.stage3, Stage3Config)
+        assert isinstance(config.routing, RoutingConfig)
+
+    def test_stage1_config_defaults(self):
+        """Stage1Config should have correct defaults."""
+        config = Stage1Config()
+        assert config.model_path == "KRLabsOrg/lettucedect-base-modernbert-en-v1"
+        assert config.augmentations == []
+        assert config.device == "cuda"
+        assert config.max_length == 4096
+
+    def test_stage2_config_defaults(self):
+        """Stage2Config should have correct defaults."""
+        config = Stage2Config()
+        assert config.components == ["ncs", "nli", "lexical"]
+        assert config.ncs_model == "minishlab/potion-base-32M"
+        assert config.nli_model == "microsoft/deberta-v3-base-mnli"
+
+    def test_stage3_config_defaults(self):
+        """Stage3Config should have correct defaults."""
+        config = Stage3Config()
+        assert config.method == Stage3Method.SEPS
+        assert config.llm_model == "meta-llama/Llama-3.2-3B"
+        assert config.num_samples == 5
+
+    def test_routing_config_defaults(self):
+        """RoutingConfig should have correct defaults."""
+        config = RoutingConfig()
+        assert config.threshold_1to2 == 0.7
+        assert config.threshold_2to3 == 0.7
+
+
+class TestCascadeConfigValidation:
+    """Test configuration validation."""
+
+    def test_stages_must_be_ascending(self):
+        """Stages must be in ascending order."""
+        with pytest.raises(ValueError, match="ascending order"):
+            CascadeConfig(stages=[2, 1])
+
+    def test_stages_descending_fails(self):
+        """Descending order should fail validation."""
+        with pytest.raises(ValueError, match="ascending order"):
+            CascadeConfig(stages=[3, 2, 1])
+
+    def test_valid_stage_orders(self):
+        """Valid stage orders should work."""
+        CascadeConfig(stages=[1])
+        CascadeConfig(stages=[1, 2])
+        CascadeConfig(stages=[1, 3])
+        CascadeConfig(stages=[2, 3])
+        CascadeConfig(stages=[1, 2, 3])
+
+    def test_cascade_config_from_dict(self):
+        """CascadeConfig should be creatable from dict."""
+        config = CascadeConfig.model_validate({
+            "stages": [1, 2],
+            "stage1": {"augmentations": ["ner"]},
+        })
+        assert config.stages == [1, 2]
+        assert config.stage1.augmentations == ["ner"]
+
+    def test_stage1_augmentation_validation(self):
+        """Stage1 augmentations must be valid options."""
+        # Valid augmentations
+        config = Stage1Config(augmentations=["ner", "numeric", "lexical"])
+        assert config.augmentations == ["ner", "numeric", "lexical"]
+
+        # Invalid augmentation should fail
+        with pytest.raises(ValueError):
+            Stage1Config(augmentations=["invalid"])
+
+
+class TestPresets:
+    """Test preset configurations."""
+
+    def test_presets_exist(self):
+        """All expected presets should exist."""
+        assert "full_cascade" in PRESETS
+        assert "fast_cascade" in PRESETS
+        assert "stage1_augmented" in PRESETS
+        assert "stage1_minimal" in PRESETS
+        assert "stage2_only" in PRESETS
+        assert "stage3_seps" in PRESETS
+        assert "stage3_self_consistency" in PRESETS
+
+    def test_full_cascade_preset(self):
+        """FULL_CASCADE should have 3 stages with augmentations."""
+        assert FULL_CASCADE.stages == [1, 2, 3]
+        assert FULL_CASCADE.stage1.augmentations == ["ner", "numeric", "lexical"]
+        assert FULL_CASCADE.stage3.method == Stage3Method.SEPS
+
+    def test_fast_cascade_preset(self):
+        """FAST_CASCADE should have only stages 1 and 2."""
+        assert FAST_CASCADE.stages == [1, 2]
+        assert FAST_CASCADE.stage1.augmentations == ["ner", "numeric", "lexical"]
+
+    def test_stage1_augmented_preset(self):
+        """STAGE1_AUGMENTED should be stage 1 only with all augmentations."""
+        assert STAGE1_AUGMENTED.stages == [1]
+        assert STAGE1_AUGMENTED.stage1.augmentations == ["ner", "numeric", "lexical"]
+
+
+class TestStage3Method:
+    """Test Stage3Method enum."""
+
+    def test_stage3_methods(self):
+        """All Stage3 methods should be available."""
+        assert Stage3Method.SEPS.value == "seps"
+        assert Stage3Method.SELF_CONSISTENCY.value == "self_consistency"
+        assert Stage3Method.SEMANTIC_ENTROPY.value == "semantic_entropy"
+
+    def test_stage3_method_in_config(self):
+        """Stage3Method can be used in Stage3Config."""
+        config = Stage3Config(method=Stage3Method.SELF_CONSISTENCY)
+        assert config.method == Stage3Method.SELF_CONSISTENCY
+
+    def test_stage3_method_from_string(self):
+        """Stage3Method can be set from string value."""
+        config = Stage3Config(method="self_consistency")
+        assert config.method == Stage3Method.SELF_CONSISTENCY


### PR DESCRIPTION
- Add Pydantic config models (CascadeConfig, Stage1/2/3Config, RoutingConfig)
- Add preset configurations (FULL_CASCADE, FAST_CASCADE, etc.)
- Add cascade types (StageResult, CascadeInput, RoutingDecision, BaseStage)
- Add LexicalOverlapCalculator utility (shared between stages)
- Add CascadeDetector shell with routing logic
- Extend factory to support method="cascade"
- Add optional dependencies for stage1, stage2, stage3, cascade
- Add unit tests for config validation (17 tests)