### PR TITLE
docs: add contributor issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug report
+description: Report a reproducible LettuceDetect problem
+title: "Bug: "
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a problem. Please include enough detail for maintainers to reproduce it.
+  - type: input
+    id: version
+    attributes:
+      label: LettuceDetect version
+      description: Output from `python -c "import lettucedetect; print(lettucedetect.__version__)"`, `pip show lettucedetect`, or the commit SHA.
+      placeholder: "0.2.0"
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12.4"
+    validations:
+      required: true
+  - type: input
+    id: transformers-version
+    attributes:
+      label: transformers version
+      description: Output from `python -c "import transformers; print(transformers.__version__)"`.
+      placeholder: "4.48.3"
+    validations:
+      required: true
+  - type: input
+    id: model-id
+    attributes:
+      label: Model id
+      description: Hugging Face model id or local checkpoint path, if relevant.
+      placeholder: "KRLabsOrg/lettucedect-base-modernbert-en-v1"
+    validations:
+      required: false
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Provide the smallest code sample, input context, answer, and command that reproduces the issue.
+      render: python
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include the full traceback or unexpected output.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment details
+      description: OS, install method, hardware notes, and any relevant dependency versions.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Suggest an improvement for LettuceDetect
+title: "Feature: "
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the use case first. It helps maintainers decide whether the change fits the project.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or use case
+      description: What are you trying to do, and what makes it difficult today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe the behavior or API you would like to see.
+    validations:
+      required: true
+  - type: input
+    id: model-id
+    attributes:
+      label: Model id
+      description: Hugging Face model id or local checkpoint path, if the request is model-specific.
+      placeholder: "KRLabsOrg/lettucedect-v2-qwen-2b"
+    validations:
+      required: false
+  - type: input
+    id: transformers-version
+    attributes:
+      label: transformers version
+      description: Include this when the request depends on transformer behavior or model loading.
+      placeholder: "4.48.3"
+    validations:
+      required: false
+  - type: textarea
+    id: example
+    attributes:
+      label: Example input or minimal reproduction
+      description: Include a short code sample, context, answer, or expected output when possible.
+      render: python
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What workaround or other design did you consider?
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- Briefly describe what this PR changes. -->
+
+## Related issue
+
+<!-- Link the issue this closes or relates to, for example: Closes #123. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Documentation
+- [ ] Tests
+- [ ] Refactor or maintenance
+
+## Testing
+
+<!-- List the exact commands you ran. -->
+
+- [ ] `ruff format --check lettucedetect/ tests/`
+- [ ] `ruff check lettucedetect/ tests/ --extend-exclude lettucedetect/integrations/`
+- [ ] `pytest tests/test_inference_pytest.py -v -k "not TestAnswerStartToken"`
+- [ ] Other:
+
+## Checklist
+
+- [ ] I kept the PR focused on one change.
+- [ ] I added or updated tests/docs when needed.
+- [ ] I checked that no secrets, API keys, or credentials are included.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,17 @@ Good areas for contribution:
 - **Tests** — increase coverage, especially for edge cases
 - **Bug fixes** — check [open issues](https://github.com/KRLabsOrg/LettuceDetect/issues)
 
+### Issue labels
+
+The maintainers use labels to make contribution scope clearer:
+
+- `good first issue` marks small, well-scoped tasks that are suitable for new contributors.
+- `help wanted` marks issues where outside implementation or investigation would be useful.
+- `bug` marks reproducible behavior that differs from the expected result.
+- `documentation` marks docs, examples, templates, and onboarding improvements.
+
+Before starting work, read the issue thread to confirm nobody has already claimed it. If the issue is unclear, ask a focused question before opening a PR.
+
 ## Building docs locally
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds bug and feature issue forms with version, model, dependency, and repro fields.
- Adds a PR template and documents how contributor labels are used.

## Related issue
Closes #45

## Type of change
- [x] Documentation

## Testing
- [x] `git diff --check HEAD~1..HEAD`
- [x] `python3 /tmp/validate_lettucedetect_templates.py`

## Checklist
- [x] I kept the PR focused on one change.
- [x] I added or updated tests/docs when needed.
- [x] I checked that no secrets, API keys, or credentials are included.
