### PR TITLE
feat: add min_confidence threshold to span predictions

### DIFF
--- a/lettucedetect/detectors/base.py
+++ b/lettucedetect/detectors/base.py
@@ -15,6 +15,7 @@ class BaseDetector(ABC):
         answer: str,
         question: str | None = None,
         output_format: str = "tokens",
+        min_confidence: float = 0.0,
     ) -> list:
         """Predict hallucination tokens or spans given passages and an answer.
 
@@ -22,30 +23,74 @@ class BaseDetector(ABC):
         :param answer: Model-generated answer to inspect.
         :param question: Original question (``None`` for summarisation).
         :param output_format: ``"tokens"`` for token-level dicts, ``"spans"`` for character spans.
+        :param min_confidence: Drop ``"spans"`` whose ``confidence`` is below this threshold
+            (in ``[0, 1]``; ``0.0`` keeps every span). Ignored for ``"tokens"`` output.
         :returns: List of predictions in requested format.
         """
         pass
 
     @abstractmethod
-    def predict_prompt(self, prompt: str, answer: str, output_format: str = "tokens") -> list:
+    def predict_prompt(
+        self, prompt: str, answer: str, output_format: str = "tokens", min_confidence: float = 0.0
+    ) -> list:
         """Predict hallucinations from a pre-built prompt string.
 
         :param prompt: Full prompt (context + question already concatenated).
         :param answer: Model-generated answer to inspect.
         :param output_format: ``"tokens"`` or ``"spans"``.
+        :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
         :returns: List of predictions in requested format.
         """
         pass
 
     @abstractmethod
     def predict_prompt_batch(
-        self, prompts: list[str], answers: list[str], output_format: str = "tokens"
+        self,
+        prompts: list[str],
+        answers: list[str],
+        output_format: str = "tokens",
+        min_confidence: float = 0.0,
     ) -> list:
         """Batch version of :meth:`predict_prompt`.
 
         :param prompts: List of full prompt strings.
         :param answers: List of answers to inspect.
         :param output_format: ``"tokens"`` or ``"spans"``.
+        :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
         :returns: List of prediction lists, one per input pair.
         """
         pass
+
+    @staticmethod
+    def _validate_min_confidence(min_confidence: float) -> None:
+        """Validate that ``min_confidence`` is a probability in ``[0, 1]``.
+
+        :param min_confidence: The threshold to validate.
+        :raises ValueError: If ``min_confidence`` is outside ``[0, 1]``.
+        """
+        if not 0.0 <= min_confidence <= 1.0:
+            raise ValueError(f"min_confidence must be in [0, 1], got {min_confidence}")
+
+    @staticmethod
+    def _filter_spans_by_confidence(
+        result: list, output_format: str, min_confidence: float
+    ) -> list:
+        """Drop spans scored below ``min_confidence`` from a ``"spans"`` result.
+
+        Only ``"spans"`` output is filtered, and only when ``min_confidence > 0``;
+        token-level output is returned unchanged so callers can still inspect
+        low-confidence tokens. Spans without a ``confidence`` key are kept, mirroring
+        the existing behaviour of the LLM detector's ``_to_spans``.
+
+        :param result: The prediction list returned by a detector.
+        :param output_format: The format the result was produced in.
+        :param min_confidence: Minimum span confidence to keep (``[0, 1]``).
+        :returns: The (possibly filtered) result list.
+        """
+        if output_format != "spans" or min_confidence <= 0.0:
+            return result
+        return [
+            span
+            for span in result
+            if span.get("confidence") is None or span["confidence"] >= min_confidence
+        ]

--- a/lettucedetect/detectors/llm.py
+++ b/lettucedetect/detectors/llm.py
@@ -455,6 +455,7 @@ class LLMDetector:
         answer: str,
         question: str | None = None,
         output_format: str = "spans",
+        min_confidence: float = 0.0,
     ) -> list:
         """Predict hallucination spans from the provided context, answer, and question.
 
@@ -462,45 +463,66 @@ class LLMDetector:
         :param answer: Model-generated answer to inspect.
         :param question: Original question (``None`` for summarisation).
         :param output_format: ``"spans"`` for character spans.
+        :param min_confidence: Drop spans whose ``confidence`` is below this threshold
+            (in ``[0, 1]``). Applied on top of the constructor-level ``min_confidence``;
+            ``0.0`` keeps every span.
         :returns: List of spans.
         """
         if output_format not in ["tokens", "spans"]:
             raise ValueError(
                 f"LLMDetector doesn't support '{output_format}' format. Use 'tokens' or 'spans'"
             )
+        self._validate_min_confidence(min_confidence)
         # Use PromptUtils to format the context and question
         full_prompt = PromptUtils.format_context(context, question, self.lang)
-        return self._predict(full_prompt, answer)
+        spans = self._predict(full_prompt, answer)
+        return self._filter_spans_by_confidence(spans, output_format, min_confidence)
 
-    def predict_prompt(self, prompt: str, answer: str, output_format: str = "spans") -> list:
+    def predict_prompt(
+        self, prompt: str, answer: str, output_format: str = "spans", min_confidence: float = 0.0
+    ) -> list:
         """Predict hallucination spans from the provided prompt and answer.
 
         :param prompt: The prompt string.
         :param answer: The answer string.
         :param output_format: ``"spans"`` for character spans.
+        :param min_confidence: Drop spans below this confidence threshold (``[0, 1]``); applied
+            on top of the constructor-level ``min_confidence``.
         :returns: List of spans.
         """
         if output_format not in ["tokens", "spans"]:
             raise ValueError(
                 f"LLMDetector doesn't support '{output_format}' format. Use 'tokens' or 'spans'"
             )
-        return self._predict(prompt, answer)
+        self._validate_min_confidence(min_confidence)
+        spans = self._predict(prompt, answer)
+        return self._filter_spans_by_confidence(spans, output_format, min_confidence)
 
     def predict_prompt_batch(
-        self, prompts: list[str], answers: list[str], output_format: str = "spans"
+        self,
+        prompts: list[str],
+        answers: list[str],
+        output_format: str = "spans",
+        min_confidence: float = 0.0,
     ) -> list:
         """Predict hallucination spans from the provided prompts and answers.
 
         :param prompts: List of prompt strings.
         :param answers: List of answer strings.
         :param output_format: ``"spans"`` for character spans.
+        :param min_confidence: Drop spans below this confidence threshold (``[0, 1]``); applied
+            on top of the constructor-level ``min_confidence``.
         :returns: List of spans.
         """
         if output_format not in ["tokens", "spans"]:
             raise ValueError(
                 f"LLMDetector doesn't support '{output_format}' format. Use 'tokens' or 'spans'"
             )
+        self._validate_min_confidence(min_confidence)
 
         with ThreadPoolExecutor(max_workers=30) as pool:
             futs = [pool.submit(self._predict, p, a) for p, a in zip(prompts, answers)]
-            return [f.result() for f in futs]
+            return [
+                self._filter_spans_by_confidence(f.result(), output_format, min_confidence)
+                for f in futs
+            ]

--- a/lettucedetect/detectors/rag_fact_checker.py
+++ b/lettucedetect/detectors/rag_fact_checker.py
@@ -44,6 +44,7 @@ class RAGFactCheckerDetector(BaseDetector):
         answer: str,
         question: str | None = None,
         output_format: str = "tokens",
+        min_confidence: float = 0.0,
         **kwargs,
     ) -> list[dict[str, Any]] | dict[str, Any]:
         """Predict hallucinations using RAGFactChecker.
@@ -52,6 +53,7 @@ class RAGFactCheckerDetector(BaseDetector):
         :param answer: Answer text to check for hallucinations
         :param question: Question (optional)
         :param output_format: "tokens", "spans", or "detailed"
+        :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
         :param kwargs: Additional arguments
 
         :return: List of predictions in lettuceDetect format, or dict for detailed format
@@ -61,6 +63,7 @@ class RAGFactCheckerDetector(BaseDetector):
                 f"Invalid output format '{output_format}'. "
                 "RAGFactChecker supports 'tokens', 'spans', or 'detailed'"
             )
+        self._validate_min_confidence(min_confidence)
 
         # Use our simple wrapper's detection method
         result = self.rag.detect_hallucinations(context, answer, question)
@@ -77,22 +80,34 @@ class RAGFactCheckerDetector(BaseDetector):
                 "fact_check_results": result.get("fact_check_results", {}),
             }
         elif output_format == "spans":
-            return self._convert_to_spans(answer, result)
+            spans = self._convert_to_spans(answer, result)
+            return self._filter_spans_by_confidence(spans, output_format, min_confidence)
         else:  # tokens
             return self._convert_to_tokens(answer, result)
 
     def predict_prompt(
-        self, prompt: str, answer: str, output_format: str = "tokens"
+        self,
+        prompt: str,
+        answer: str,
+        output_format: str = "tokens",
+        min_confidence: float = 0.0,
     ) -> list[dict[str, Any]]:
         """Predict using a single prompt string as context."""
-        return self.predict([prompt], answer, output_format=output_format)
+        return self.predict(
+            [prompt], answer, output_format=output_format, min_confidence=min_confidence
+        )
 
     def predict_prompt_batch(
-        self, prompts: list[str], answers: list[str], output_format: str = "tokens"
+        self,
+        prompts: list[str],
+        answers: list[str],
+        output_format: str = "tokens",
+        min_confidence: float = 0.0,
     ) -> list[list[dict[str, Any]]]:
         """Batch prediction using RAGFactChecker's batch processing."""
         if len(prompts) != len(answers):
             raise ValueError("Number of prompts must match number of answers")
+        self._validate_min_confidence(min_confidence)
 
         contexts = [[prompt] for prompt in prompts]  # Convert prompts to context lists
         rag_results = self.rag.detect_hallucinations_batch(contexts, answers)
@@ -104,6 +119,9 @@ class RAGFactCheckerDetector(BaseDetector):
                 converted = self._convert_to_tokens(answer, rag_result)
             elif output_format == "spans":
                 converted = self._convert_to_spans(answer, rag_result)
+                converted = self._filter_spans_by_confidence(
+                    converted, output_format, min_confidence
+                )
             else:
                 raise ValueError(f"Unknown output format: {output_format}")
             converted_results.append(converted)

--- a/lettucedetect/detectors/transformer.py
+++ b/lettucedetect/detectors/transformer.py
@@ -347,6 +347,7 @@ class TransformerDetector(BaseDetector):
         answer: str,
         question: str | None = None,
         output_format: str = "tokens",
+        min_confidence: float = 0.0,
     ) -> list:
         """Predict hallucination tokens or spans from the provided context, answer, and question.
 
@@ -354,6 +355,8 @@ class TransformerDetector(BaseDetector):
         :param answer: Model-generated answer to inspect.
         :param question: Original question (``None`` for summarisation).
         :param output_format: ``"tokens"`` for token-level dicts, ``"spans"`` for character spans.
+        :param min_confidence: Drop ``"spans"`` whose ``confidence`` is below this threshold
+            (in ``[0, 1]``; ``0.0`` keeps every span). Ignored for ``"tokens"`` output.
         :returns: List of predictions in requested format.
         """
         if output_format not in ("tokens", "spans"):
@@ -361,6 +364,7 @@ class TransformerDetector(BaseDetector):
                 f"TransformerDetector doesn't support '{output_format}' format. "
                 "Use 'tokens' or 'spans'"
             )
+        self._validate_min_confidence(min_confidence)
 
         groups = self._group_passages_into_chunks(context, question, answer)
 
@@ -375,9 +379,11 @@ class TransformerDetector(BaseDetector):
 
         if output_format == "spans" and self.typer is not None:
             result = self.typer.type_spans(answer, "\n".join(context), result)
-        return result
+        return self._filter_spans_by_confidence(result, output_format, min_confidence)
 
-    def predict_prompt(self, prompt: str, answer: str, output_format: str = "tokens") -> list:
+    def predict_prompt(
+        self, prompt: str, answer: str, output_format: str = "tokens", min_confidence: float = 0.0
+    ) -> list:
         """Predict hallucination tokens or spans from the provided prompt and answer.
 
         Note: unlike :meth:`predict`, this method does **not** chunk the prompt
@@ -388,6 +394,7 @@ class TransformerDetector(BaseDetector):
         :param prompt: The prompt string.
         :param answer: The answer string.
         :param output_format: ``"tokens"`` or ``"spans"``.
+        :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
         :returns: List of predictions in requested format.
         """
         if output_format not in ("tokens", "spans"):
@@ -395,6 +402,7 @@ class TransformerDetector(BaseDetector):
                 f"TransformerDetector doesn't support '{output_format}' format. "
                 "Use 'tokens' or 'spans'"
             )
+        self._validate_min_confidence(min_confidence)
         # Warn if the input will be truncated.
         total_tokens = self.tokenizer(prompt, answer, add_special_tokens=True, return_tensors="pt")[
             "input_ids"
@@ -410,16 +418,24 @@ class TransformerDetector(BaseDetector):
         spans = self._predict_single(prompt, answer, output_format)
         if output_format == "spans" and self.typer is not None:
             spans = self.typer.type_spans(answer, prompt, spans)
-        return spans
+        return self._filter_spans_by_confidence(spans, output_format, min_confidence)
 
     def predict_prompt_batch(
-        self, prompts: list[str], answers: list[str], output_format: str = "tokens"
+        self,
+        prompts: list[str],
+        answers: list[str],
+        output_format: str = "tokens",
+        min_confidence: float = 0.0,
     ) -> list:
         """Predict hallucination tokens or spans from the provided prompts and answers.
 
         :param prompts: List of prompt strings.
         :param answers: List of answer strings.
         :param output_format: ``"tokens"`` or ``"spans"``.
+        :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
         :returns: List of prediction lists, one per input pair.
         """
-        return [self.predict_prompt(p, a, output_format) for p, a in zip(prompts, answers)]
+        return [
+            self.predict_prompt(p, a, output_format, min_confidence)
+            for p, a in zip(prompts, answers)
+        ]

--- a/lettucedetect/models/inference.py
+++ b/lettucedetect/models/inference.py
@@ -30,26 +30,41 @@ class HallucinationDetector:
         answer: str,
         question: str | None = None,
         output_format: str = "tokens",
+        min_confidence: float = 0.0,
     ) -> list:
         """Predict hallucination tokens or spans given passages and an answer.
 
         This is the call most RAG pipelines use.
 
+        :param min_confidence: Drop ``"spans"`` whose ``confidence`` is below this threshold
+            (in ``[0, 1]``; ``0.0`` keeps every span). Ignored for ``"tokens"`` output.
+
         See the concrete detector docs for the structure of the returned list.
         """
-        return self.detector.predict(context, answer, question, output_format)
+        return self.detector.predict(
+            context, answer, question, output_format, min_confidence=min_confidence
+        )
 
-    def predict_prompt(self, prompt: str, answer: str, output_format: str = "tokens") -> list:
+    def predict_prompt(
+        self, prompt: str, answer: str, output_format: str = "tokens", min_confidence: float = 0.0
+    ) -> list:
         """Predict hallucinations when you already have a *single* full prompt string.
 
         :param prompt: The prompt string.
         :param answer: The answer string.
         :param output_format: "tokens" to return token-level predictions, or "spans" to return grouped spans.
+        :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
         """
-        return self.detector.predict_prompt(prompt, answer, output_format)
+        return self.detector.predict_prompt(
+            prompt, answer, output_format, min_confidence=min_confidence
+        )
 
     def predict_prompt_batch(
-        self, prompts: list[str], answers: list[str], output_format: str = "tokens"
+        self,
+        prompts: list[str],
+        answers: list[str],
+        output_format: str = "tokens",
+        min_confidence: float = 0.0,
     ) -> list:
         """Batch version of :py:meth:`predict_prompt`.
 
@@ -58,5 +73,8 @@ class HallucinationDetector:
         :param prompts: List of prompt strings.
         :param answers: List of answer strings.
         :param output_format: "tokens" to return token-level predictions, or "spans" to return grouped spans.
+        :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
         """
-        return self.detector.predict_prompt_batch(prompts, answers, output_format)
+        return self.detector.predict_prompt_batch(
+            prompts, answers, output_format, min_confidence=min_confidence
+        )

--- a/tests/test_inference_pytest.py
+++ b/tests/test_inference_pytest.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from lettucedetect.datasets.hallucination_dataset import HallucinationDataset
+from lettucedetect.detectors.base import BaseDetector
 from lettucedetect.detectors.prompt_utils import PromptUtils
 from lettucedetect.detectors.transformer import TransformerDetector
 from lettucedetect.models.inference import HallucinationDetector
@@ -418,3 +419,155 @@ class TestAnswerStartToken:
         # The answer tokens should be at the end (before trailing [SEP])
         # Verify by checking that the text at answer_start offset is non-empty
         assert offsets[answer_start][1].item() > offsets[answer_start][0].item()
+
+
+class TestMinConfidenceFilter:
+    """Unit tests for the shared min_confidence helpers on BaseDetector."""
+
+    @pytest.mark.parametrize("value", [-0.1, -1.0, 1.1, 2.0])
+    def test_validate_rejects_out_of_range(self, value):
+        """Values outside [0, 1] raise a ValueError mentioning min_confidence."""
+        with pytest.raises(ValueError, match="min_confidence"):
+            BaseDetector._validate_min_confidence(value)
+
+    @pytest.mark.parametrize("value", [0.0, 0.5, 1.0])
+    def test_validate_accepts_in_range(self, value):
+        """Values within [0, 1] are accepted (no exception)."""
+        BaseDetector._validate_min_confidence(value)
+
+    def test_filter_drops_low_confidence_spans(self):
+        """Spans below the threshold are dropped from a spans result."""
+        spans = [
+            {"start": 0, "end": 3, "confidence": 0.55, "text": "foo"},
+            {"start": 4, "end": 7, "confidence": 0.85, "text": "bar"},
+        ]
+        filtered = BaseDetector._filter_spans_by_confidence(spans, "spans", 0.7)
+        assert filtered == [{"start": 4, "end": 7, "confidence": 0.85, "text": "bar"}]
+
+    def test_filter_zero_threshold_is_noop(self):
+        """A 0.0 threshold returns the spans unchanged (backward compatible)."""
+        spans = [{"start": 0, "end": 3, "confidence": 0.1, "text": "foo"}]
+        assert BaseDetector._filter_spans_by_confidence(spans, "spans", 0.0) == spans
+
+    def test_filter_ignores_token_output(self):
+        """Token-level output is never filtered, even at a high threshold."""
+        tokens = [{"token": "foo", "pred": 1, "prob": 0.2}]
+        assert BaseDetector._filter_spans_by_confidence(tokens, "tokens", 0.9) == tokens
+
+    def test_filter_keeps_spans_without_confidence(self):
+        """Spans lacking a confidence key are kept (e.g. LLM without reasoning)."""
+        spans = [{"start": 0, "end": 3, "text": "foo"}]
+        assert BaseDetector._filter_spans_by_confidence(spans, "spans", 0.9) == spans
+
+
+class TestTransformerMinConfidence:
+    """min_confidence behaviour wired through TransformerDetector."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Build a TransformerDetector with mocked model/tokenizer."""
+        with (
+            patch(
+                "lettucedetect.detectors.transformer.AutoTokenizer.from_pretrained",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "lettucedetect.detectors.transformer.AutoModelForTokenClassification.from_pretrained",
+                return_value=MagicMock(),
+            ),
+        ):
+            self.detector = TransformerDetector(model_path="dummy_path")
+            yield
+
+    def test_predict_spans_filtered_by_min_confidence(self):
+        """predict(output_format='spans') drops spans below the threshold."""
+        spans = [
+            {"start": 0, "end": 3, "confidence": 0.55, "text": "foo"},
+            {"start": 4, "end": 7, "confidence": 0.85, "text": "bar"},
+        ]
+        with (
+            patch.object(
+                TransformerDetector, "_group_passages_into_chunks", return_value=[["ctx"]]
+            ),
+            patch.object(TransformerDetector, "_predict_single", return_value=spans),
+        ):
+            result = self.detector.predict(
+                ["ctx"], "foo bar", output_format="spans", min_confidence=0.7
+            )
+        assert result == [{"start": 4, "end": 7, "confidence": 0.85, "text": "bar"}]
+
+    def test_predict_tokens_ignore_min_confidence(self):
+        """predict(output_format='tokens') keeps every token regardless of threshold."""
+        tokens = [
+            {"token": "foo", "pred": 1, "prob": 0.55},
+            {"token": "bar", "pred": 0, "prob": 0.10},
+        ]
+        with (
+            patch.object(
+                TransformerDetector, "_group_passages_into_chunks", return_value=[["ctx"]]
+            ),
+            patch.object(TransformerDetector, "_predict_single", return_value=tokens),
+        ):
+            result = self.detector.predict(
+                ["ctx"], "foo bar", output_format="tokens", min_confidence=0.9
+            )
+        assert result == tokens
+
+    @pytest.mark.parametrize("bad_value", [-0.1, 1.5])
+    @pytest.mark.parametrize("method_name", ["predict", "predict_prompt"])
+    def test_invalid_min_confidence_raises(self, method_name, bad_value):
+        """Out-of-range min_confidence raises ValueError before any inference."""
+        args = (["ctx"], "ans", "q") if method_name == "predict" else ("prompt", "ans")
+        with pytest.raises(ValueError, match="min_confidence"):
+            getattr(self.detector, method_name)(
+                *args, output_format="spans", min_confidence=bad_value
+            )
+
+    def test_predict_prompt_batch_respects_min_confidence(self):
+        """The batch path applies the threshold to each item's spans."""
+        spans = [
+            {"start": 0, "end": 3, "confidence": 0.40, "text": "foo"},
+            {"start": 4, "end": 7, "confidence": 0.90, "text": "bar"},
+        ]
+        # predict_prompt measures token length first; return a small fixed count.
+        self.detector.tokenizer.return_value = {"input_ids": torch.zeros(1, 4, dtype=torch.long)}
+        with patch.object(TransformerDetector, "_predict_single", return_value=spans):
+            results = self.detector.predict_prompt_batch(
+                ["p1"], ["foo bar"], output_format="spans", min_confidence=0.5
+            )
+        assert results == [[{"start": 4, "end": 7, "confidence": 0.90, "text": "bar"}]]
+
+
+class TestFacadeMinConfidence:
+    """The HallucinationDetector facade threads min_confidence to the detector."""
+
+    @staticmethod
+    def _facade_with_mock() -> tuple[HallucinationDetector, MagicMock]:
+        """Build a facade whose underlying detector is a MagicMock."""
+        mock_detector = MagicMock()
+        with patch(
+            "lettucedetect.detectors.transformer.TransformerDetector", return_value=mock_detector
+        ):
+            detector = HallucinationDetector(method="transformer")
+        return detector, mock_detector
+
+    def test_predict_passes_min_confidence(self):
+        """predict() forwards min_confidence to the detector as a keyword."""
+        detector, mock_detector = self._facade_with_mock()
+        mock_detector.predict.return_value = []
+        detector.predict(["ctx"], "ans", "q", output_format="spans", min_confidence=0.8)
+        assert mock_detector.predict.call_args.kwargs["min_confidence"] == 0.8
+
+    def test_predict_prompt_passes_min_confidence(self):
+        """predict_prompt() forwards min_confidence to the detector as a keyword."""
+        detector, mock_detector = self._facade_with_mock()
+        mock_detector.predict_prompt.return_value = []
+        detector.predict_prompt("prompt", "ans", output_format="spans", min_confidence=0.6)
+        assert mock_detector.predict_prompt.call_args.kwargs["min_confidence"] == 0.6
+
+    def test_predict_prompt_batch_passes_min_confidence(self):
+        """predict_prompt_batch() forwards min_confidence to the detector as a keyword."""
+        detector, mock_detector = self._facade_with_mock()
+        mock_detector.predict_prompt_batch.return_value = []
+        detector.predict_prompt_batch(["p"], ["a"], output_format="spans", min_confidence=0.3)
+        assert mock_detector.predict_prompt_batch.call_args.kwargs["min_confidence"] == 0.3


### PR DESCRIPTION
## Summary

Closes #41.

Adds an optional `min_confidence: float = 0.0` keyword to the public prediction
methods so callers can threshold span confidence in a single place instead of
re-implementing a post-filter in every RAG pipeline:

- `HallucinationDetector.predict()` / `predict_prompt()` / `predict_prompt_batch()` (facade)
- `TransformerDetector`, `LLMDetector`, and `RAGFactCheckerDetector` (all three concrete detectors)

When `min_confidence > 0`, spans whose `confidence` is below the threshold are
dropped from `output_format="spans"` results. Token output is never filtered, so
callers can still inspect low-confidence tokens. `ValueError` is raised for values
outside `[0, 1]`.

## Why thread it through the whole hierarchy

The facade delegates to whichever detector it holds, so adding the kwarg to only
one detector would break the facade for the others. To keep the interface
consistent I added the parameter to the `BaseDetector` abstract methods and all
three detectors, with two shared helpers on `BaseDetector`
(`_validate_min_confidence`, `_filter_spans_by_confidence`) so the validation and
filtering logic lives in one place.

`LLMDetector` already exposes a constructor-level `min_confidence` (applied in
`_to_spans`). The new per-call kwarg composes with it as an additional floor and
leaves that behaviour unchanged.

## Backward compatibility

The default `0.0` is a no-op, so existing callers see no behaviour change. Spans
that carry no `confidence` key are kept, mirroring the current `_to_spans`
semantics.

## Testing

- `ruff format --check` and `ruff check` pass on the changed files.
- `pytest tests/test_inference_pytest.py tests/test_factory_pytest.py -k "not TestAnswerStartToken"`
  passes (43 passed) — this is the CONTRIBUTING fast subset that skips the
  model-download tests. 22 new tests cover validation, the span filter
  (drop/keep/zero-noop/tokens-unaffected/missing-confidence-key), the
  `TransformerDetector` spans/tokens/batch paths, and facade pass-through.
- I was not able to run the two `TestAnswerStartToken` cases locally as they
  download `bert-base-uncased`; they are untouched by this change.

Thanks for maintaining LettuceDetect! Happy to adjust the approach, naming, or
docs coverage if you'd prefer something different.
