### PR TITLE
docs: document min confidence edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,22 @@ The model can output predictions in two formats:
 }]
 ```
 
+Use `min_confidence` with span output to drop predictions below a threshold:
+
+```python
+detector.predict(
+    context=contexts,
+    question=question,
+    answer=answer,
+    output_format="spans",
+    min_confidence=0.8,
+)
+```
+
+For transformer detectors, emitted hallucination spans already have
+confidence values of at least `0.5`, so thresholds below `0.5` are no-ops;
+higher thresholds raise that floor.
+
 ### Token Format
 ```python
 [{

--- a/lettucedetect/detectors/rag_fact_checker.py
+++ b/lettucedetect/detectors/rag_fact_checker.py
@@ -54,6 +54,8 @@ class RAGFactCheckerDetector(BaseDetector):
         :param question: Question (optional)
         :param output_format: "tokens", "spans", or "detailed"
         :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
+            Does not filter ``output_format="detailed"``; detailed output returns
+            the unfiltered spans, triplets, and fact-check results.
         :param kwargs: Additional arguments
 
         :return: List of predictions in lettuceDetect format, or dict for detailed format


### PR DESCRIPTION
Summary:
- document `min_confidence` in the README span-output section with a short example
- note that transformer span confidences start at 0.5, so lower thresholds are no-ops
- clarify that `RAGFactCheckerDetector.predict(..., output_format="detailed")` is not filtered by `min_confidence`

Validation:
- `python -m compileall lettucedetect\detectors\rag_fact_checker.py`
- `python -m ruff check README.md lettucedetect\detectors\rag_fact_checker.py`
- `git diff --check`

Closes #64