### PR TITLE
fix: LLMDetector must subclass BaseDetector

### DIFF
--- a/lettucedetect/detectors/llm.py
+++ b/lettucedetect/detectors/llm.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from string import Template
 
 from lettucedetect.datasets.taxonomy import CATEGORY_DEFINITIONS, SUBCATEGORY_DEFINITIONS
+from lettucedetect.detectors.base import BaseDetector
 from lettucedetect.detectors.cache import CacheManager
 from lettucedetect.detectors.llm_client import (
     LLMClient,
@@ -49,7 +50,7 @@ _VERIFY_SYSTEM = (
 )
 
 
-class LLMDetector:
+class LLMDetector(BaseDetector):
     """LLM-powered hallucination detector."""
 
     def __init__(

--- a/tests/test_factory_pytest.py
+++ b/tests/test_factory_pytest.py
@@ -52,3 +52,16 @@ class TestMakeDetector:
         assert "transformer" in message
         assert "llm" in message
         assert "rag_fact_checker" in message
+
+
+class TestDetectorHierarchy:
+    """Every concrete detector must subclass BaseDetector (``predict`` relies on its helpers)."""
+
+    def test_all_detectors_inherit_base_detector(self):
+        from lettucedetect.detectors.base import BaseDetector
+        from lettucedetect.detectors.llm import LLMDetector
+        from lettucedetect.detectors.rag_fact_checker import RAGFactCheckerDetector
+        from lettucedetect.detectors.transformer import TransformerDetector
+
+        for cls in (LLMDetector, TransformerDetector, RAGFactCheckerDetector):
+            assert issubclass(cls, BaseDetector)

--- a/tests/test_factory_pytest.py
+++ b/tests/test_factory_pytest.py
@@ -58,6 +58,7 @@ class TestDetectorHierarchy:
     """Every concrete detector must subclass BaseDetector (``predict`` relies on its helpers)."""
 
     def test_all_detectors_inherit_base_detector(self):
+        """LLMDetector, TransformerDetector and RAGFactCheckerDetector subclass BaseDetector."""
         from lettucedetect.detectors.base import BaseDetector
         from lettucedetect.detectors.llm import LLMDetector
         from lettucedetect.detectors.rag_fact_checker import RAGFactCheckerDetector


### PR DESCRIPTION
## What

`method="llm"` crashes with `AttributeError: 'LLMDetector' object has no attribute '_validate_min_confidence'` on every `predict()` call since 0.2.1.

## Why

#62 added `self._validate_min_confidence(...)` at the top of every detector's `predict()` entrypoints. The helper lives on `BaseDetector` — `TransformerDetector` and `RAGFactCheckerDetector` inherit it, but `LLMDetector` predates the base class and was never made a subclass, so the llm method has been broken on main and in the 0.2.1 wheel ever since.

## Fix

Make `LLMDetector` subclass `BaseDetector` (it already implements the full interface — `predict`, `predict_prompt`, `predict_prompt_batch`), plus a hierarchy regression test so a future detector can't repeat this.

## Test Plan

- `tests/test_factory_pytest.py` — 5 passed (incl. new `TestDetectorHierarchy`)
- End-to-end: `lettucedect-v2-qwen-2b` served via vLLM, `HallucinationDetector(method="llm", base_url=...)` → correct typed spans on smoke sample + 100-sample HaluEval run (F1 0.848)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] I certify that I have the right to submit this code under the project license, and that my contribution complies with the Contributor Covenant.
