### PR TITLE
docs: public roadmap, brand-aligned docs theme, EuroBERT transformers note

### DIFF
--- a/PUBLIC_ROADMAP.md
+++ b/PUBLIC_ROADMAP.md
@@ -1,0 +1,37 @@
+# LettuceDetect roadmap
+
+LettuceDetect is maintained and evidence-driven. This roadmap separates near-term release work from research directions, and it intentionally has no delivery dates. Every item links to a GitHub issue where the discussion happens; milestones group them.
+
+## Now: [v0.3 — Real batching, lighter installs](https://github.com/KRLabsOrg/LettuceDetect/milestone/1)
+
+The next PyPI release is about making the existing detectors cheaper to install and faster to run, not about new detection methods.
+
+- [Real batched inference](https://github.com/KRLabsOrg/LettuceDetect/issues/23): `predict_prompt_batch` currently loops one sample at a time; the plan is padded-batch tokenization with a single forward pass.
+- [Lighter installs](https://github.com/KRLabsOrg/LettuceDetect/issues/69): lazy top-level imports so the LLM detector never touches torch. How to slim the default install without breaking existing users is an open design question; input welcome on the issue.
+- [Fix tokens output from the LLM detector](https://github.com/KRLabsOrg/LettuceDetect/issues/65): `output_format="tokens"` should return token-level output, matching the transformer detector.
+- [A `lettucedetect` CLI](https://github.com/KRLabsOrg/LettuceDetect/issues/47) and [a latency/throughput benchmark](https://github.com/KRLabsOrg/LettuceDetect/issues/58): both have contributor PRs in review.
+- [Document `min_confidence` edge cases](https://github.com/KRLabsOrg/LettuceDetect/issues/64): contributor PR in review.
+
+## Next: [Typed spans in the wild](https://github.com/KRLabsOrg/LettuceDetect/milestone/3)
+
+The detectors already emit typed spans (category and subcategory per detected span); this milestone makes that visible and usable in real workflows.
+
+- [Typed spans in the Streamlit demo](https://github.com/KRLabsOrg/LettuceDetect/issues/57)
+- [Dataset-level hallucination-rate evaluation and reporting](https://github.com/KRLabsOrg/LettuceDetect/issues/56)
+- [A Claude Code hook that flags hallucinations in agent answers](https://github.com/KRLabsOrg/LettuceDetect/issues/50)
+
+## Exploring: [safety spans and long context](https://github.com/KRLabsOrg/LettuceDetect/milestone/2)
+
+A collaborator playground. These issues are experiments and design discussions, not committed release features or stable APIs. Reproducible comparisons, failure analyses, and short design notes are valuable contributions even when the result is negative.
+
+- [Span-based safety classification](https://github.com/KRLabsOrg/LettuceDetect/issues/43) and [span-level supervision from Aegis 2.0](https://github.com/KRLabsOrg/LettuceDetect/issues/44): extending span detection from hallucination to safety dimensions.
+- [Span-level prompt-injection and jailbreak detection](https://github.com/KRLabsOrg/LettuceDetect/issues/55)
+- [Long-context bidirectional encoders](https://github.com/KRLabsOrg/LettuceDetect/issues/42)
+- [Zero-shot token classification via label conditioning](https://github.com/KRLabsOrg/LettuceDetect/issues/70): GLiNER-style label conditioning, but token-level, so unseen span taxonomies work without retraining.
+
+## How this roadmap changes
+
+- Items move from Exploring to Now only with evidence: a working prototype, a benchmark result, or a design note that survived discussion.
+- Simpler baselines and negative results can narrow or stop a direction.
+- Anything user-facing lands with documentation and an entry in the changelog.
+- Suggestions belong in issues; the roadmap is updated when milestones change, not on a schedule.

--- a/PUBLIC_ROADMAP.md
+++ b/PUBLIC_ROADMAP.md
@@ -28,6 +28,7 @@ A collaborator playground. These issues are experiments and design discussions, 
 - [Span-level prompt-injection and jailbreak detection](https://github.com/KRLabsOrg/LettuceDetect/issues/55)
 - [Long-context bidirectional encoders](https://github.com/KRLabsOrg/LettuceDetect/issues/42)
 - [Zero-shot token classification via label conditioning](https://github.com/KRLabsOrg/LettuceDetect/issues/70): GLiNER-style label conditioning, but token-level, so unseen span taxonomies work without retraining.
+- [A rule-based detection tier](https://github.com/KRLabsOrg/LettuceDetect/issues/15): interpretable lexical checks (numbers, dates, entities unsupported by the context) as a zero-cost, torch-free first tier, potentially synthesized from RAGTruth annotations with [RuleChef](https://github.com/KRLabsOrg/rulechef).
 
 ## How this roadmap changes
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Our models are inspired from the [Luna](https://aclanthology.org/2025.coling-ind
 [![arXiv](https://img.shields.io/badge/arXiv-2502.17125-b31b1b.svg)](https://arxiv.org/abs/2502.17125)
 [![Discord](https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white)](https://discord.gg/RspnGxJNMa)
 
+See the [public roadmap](PUBLIC_ROADMAP.md) for what is landing in the next release and the research directions open for collaboration.
+
 ## Highlights
 
 - LettuceDetect addresses two critical limitations of existing hallucination detection models:
@@ -84,6 +86,8 @@ Check out our models published to Huggingface:
 
 **Multilingual Models**:
 We've trained 210m and 610m variants of EuroBERT, see our HuggingFace collection: [HF models](https://huggingface.co/collections/KRLabsOrg/multilingual-hallucination-detection-682a2549c18ecd32689231ce)
+
+> **Note:** the EuroBERT models load remote code that is not yet compatible with transformers 5.x. When using them, install `pip install "transformers>=4.48.3,<5"` (see [#33](https://github.com/KRLabsOrg/LettuceDetect/issues/33)). ModernBERT models are unaffected.
 
 **Code / Tool / Agentic Models (v2 — new)**:
 - Generative (emits typed spans in one pass): [KRLabsOrg/lettucedect-v2-qwen-2b](https://huggingface.co/KRLabsOrg/lettucedect-v2-qwen-2b)

--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -1,17 +1,101 @@
-/* KR Labs brand colors — aligned with krlabs.eu (#ff5757) */
+/* LettuceDetect docs — KR Labs brand (Signal #FF3D5A, Ink, Space Grotesk / Inter / Space Mono) */
 
 :root {
-  --md-primary-fg-color: #ff5757;
-  --md-primary-fg-color--light: #ff7a7a;
-  --md-primary-fg-color--dark: #e04040;
-  --md-accent-fg-color: #ff5757;
-  --md-accent-fg-color--transparent: rgba(255, 87, 87, 0.1);
+  --md-primary-fg-color: #FF3D5A;
+  --md-primary-fg-color--light: #FF5A72;
+  --md-primary-fg-color--dark: #D92E4C;
+  --md-accent-fg-color: #FF3D5A;
+  --md-accent-fg-color--transparent: #FF3D5A26;
 }
 
 [data-md-color-scheme="slate"] {
-  --md-primary-fg-color: #ff5757;
-  --md-primary-fg-color--light: #ff7a7a;
-  --md-primary-fg-color--dark: #e04040;
-  --md-accent-fg-color: #ff5757;
-  --md-accent-fg-color--transparent: rgba(255, 87, 87, 0.1);
+  /* Signal-dark: more luminous to hold contrast on Ink-dark */
+  --md-primary-fg-color: #FF5A72;
+  --md-primary-fg-color--light: #FF7A8D;
+  --md-primary-fg-color--dark: #D92E4C;
+  --md-accent-fg-color: #FF5A72;
+  --md-accent-fg-color--transparent: #FF5A7226;
+  --md-default-bg-color: #0F1115; /* Ink-dark */
+}
+
+/* Typography: Inter for body, Space Mono for code, Space Grotesk for display */
+:root {
+  --md-text-font: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  --md-code-font: "Space Mono", "JetBrains Mono", "SF Mono", Menlo, Consolas, monospace;
+}
+
+.md-typeset {
+  font-size: 0.78rem;
+  line-height: 1.65;
+  color: #0F0F0F; /* Ink */
+}
+
+[data-md-color-scheme="slate"] .md-typeset {
+  color: #F5F6F8; /* Paper-dark */
+}
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4 {
+  font-family: "Space Grotesk", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-weight: 700;
+  letter-spacing: -0.015em;
+  color: #0F0F0F;
+}
+
+[data-md-color-scheme="slate"] .md-typeset h1,
+[data-md-color-scheme="slate"] .md-typeset h2,
+[data-md-color-scheme="slate"] .md-typeset h3,
+[data-md-color-scheme="slate"] .md-typeset h4 {
+  color: #F5F6F8;
+}
+
+/* Header: site name in Space Grotesk, translucent bar */
+.md-header__topic,
+.md-header__title {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+}
+
+.md-header {
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  background-color: hsla(0, 0%, 100%, 0.85);
+  color: #0F0F0F;
+  box-shadow: 0 1px 0 hsl(220 14% 90%);
+}
+
+[data-md-color-scheme="slate"] .md-header {
+  background-color: hsla(225, 17%, 7%, 0.85);
+  color: #F5F6F8;
+  box-shadow: 0 1px 0 hsl(220 10% 18%);
+}
+
+/* Subtle Signal-tinted background wash */
+body {
+  background-image:
+    radial-gradient(circle at 10% 0%, hsl(220 20% 97%) 0%, transparent 40%),
+    radial-gradient(circle at 90% 0%, hsl(351 100% 97%) 0%, transparent 35%);
+  background-attachment: fixed;
+}
+
+[data-md-color-scheme="slate"] body {
+  background-image:
+    radial-gradient(circle at 10% 0%, hsl(220 20% 8%) 0%, transparent 40%),
+    radial-gradient(circle at 90% 0%, hsl(351 40% 10%) 0%, transparent 35%);
+}
+
+/* Code blocks */
+.md-typeset code {
+  border-radius: 4px;
+}
+
+.md-typeset pre > code {
+  border-radius: 6px;
+}
+
+/* Nav sidebar */
+.md-nav__link--active {
+  font-weight: 600;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,7 +25,7 @@ theme:
         name: Switch to light mode
   font:
     text: Inter
-    code: JetBrains Mono
+    code: Space Mono
   features:
     - navigation.sections
     - navigation.expand


### PR DESCRIPTION
## What

- Adds `PUBLIC_ROADMAP.md`: undated, issue-linked roadmap grouped by the three new milestones (v0.3, typed spans in the wild, research), plus a pointer line in the README.
- Re-brands the MkDocs theme to the current KR Labs palette and type (Signal #FF3D5A, Space Grotesk/Inter/Space Mono); replaces the old #ff5757 accent.
- Adds the `transformers<5` note for EuroBERT models promised in #33.

## Checklist

- [x] Docs-only change, no runtime code touched.

- [x] I certify that I have the right to submit this code and that it may be distributed under the repository's MIT license