### PR TITLE
feat: showcase typed spans in Streamlit demo

### DIFF
--- a/demo/streamlit_demo.py
+++ b/demo/streamlit_demo.py
@@ -1,22 +1,60 @@
-import streamlit as st
-import streamlit.components.v1 as components
+"""Streamlit demo for binary and taxonomy-typed hallucination spans."""
 
-from lettucedetect.models.inference import HallucinationDetector
+from __future__ import annotations
+
+from html import escape
+from typing import Any
+
+CATEGORY_COLORS = {
+    "contradiction": "rgba(255, 99, 71, 0.35)",
+    "unsupported_addition": "rgba(255, 193, 7, 0.35)",
+    "fabricated_reference": "rgba(156, 39, 176, 0.30)",
+}
+DEFAULT_SPAN_COLOR = "rgba(255, 99, 71, 0.30)"
+
+MODEL_OPTIONS = {
+    "Typed spans (v2 encoder cascade)": {
+        "model_path": "KRLabsOrg/lettucedect-v2-mmbert-base",
+        "taxonomy_head": "KRLabsOrg/lettucedect-v2-taxonomy-head",
+    },
+    "Binary spans (ModernBERT)": {
+        "model_path": "KRLabsOrg/lettucedect-base-modernbert-en-v1",
+    },
+}
 
 
-def create_interactive_text(text: str, spans: list[dict[str, int | float]]) -> str:
-    """Create interactive HTML with highlighting and hover effects.
+def create_interactive_text(text: str, spans: list[dict[str, Any]]) -> str:
+    """Create highlighted HTML for typed and untyped hallucination spans.
 
-    :param text: The text to create the interactive text for.
-    :param spans: The spans to highlight.
-    :return: The interactive text.
+    :param text: The answer text to highlight.
+    :param spans: Span dictionaries containing offsets and optional taxonomy labels.
+    :return: HTML containing the highlighted answer.
     """
     html_text = text
 
-    for span in sorted(spans, key=lambda x: x["start"], reverse=True):
-        span_text = text[span["start"] : span["end"]]
-        highlighted_span = f'<span class="hallucination" title="Confidence: {span["confidence"]:.3f}">{span_text}</span>'
-        html_text = html_text[: span["start"]] + highlighted_span + html_text[span["end"] :]
+    for span in sorted(spans, key=lambda item: item["start"], reverse=True):
+        start = int(span["start"])
+        end = int(span["end"])
+        span_text = escape(text[start:end])
+        category = span.get("category")
+        subcategory = span.get("subcategory")
+        confidence = span.get("confidence")
+        color = CATEGORY_COLORS.get(str(category), DEFAULT_SPAN_COLOR)
+
+        tooltip_parts = []
+        if category:
+            tooltip_parts.append(f"Category: {category}")
+        if subcategory:
+            tooltip_parts.append(f"Subcategory: {subcategory}")
+        if isinstance(confidence, int | float):
+            tooltip_parts.append(f"Confidence: {confidence:.3f}")
+        tooltip = escape(" | ".join(tooltip_parts) or "Hallucination", quote=True)
+
+        highlighted_span = (
+            f'<span class="hallucination" style="background-color: {color}" '
+            f'title="{tooltip}">{span_text}</span>'
+        )
+        html_text = html_text[:start] + highlighted_span + html_text[end:]
 
     return f"""
     <style>
@@ -27,20 +65,38 @@ def create_interactive_text(text: str, spans: list[dict[str, int | float]]) -> s
             padding: 20px;
         }}
         .hallucination {{
-            background-color: rgba(255, 99, 71, 0.3);
             padding: 2px;
             border-radius: 3px;
             cursor: help;
         }}
         .hallucination:hover {{
-            background-color: rgba(255, 99, 71, 0.5);
+            filter: saturate(1.5);
         }}
     </style>
     <div class="container">{html_text}</div>
     """
 
 
-def main():
+def create_legend_html() -> str:
+    """Return a compact legend for typed span categories."""
+    items = "".join(
+        (
+            '<span style="display: inline-flex; align-items: center; margin-right: 1rem">'
+            f'<span style="background: {color}; width: 0.8rem; height: 0.8rem; '
+            f'display: inline-block; margin-right: 0.3rem"></span>{escape(category)}</span>'
+        )
+        for category, color in CATEGORY_COLORS.items()
+    )
+    return f'<div style="margin: 0.5rem 0 1rem"><strong>Categories:</strong> {items}</div>'
+
+
+def main() -> None:
+    """Run the Streamlit demo."""
+    import streamlit as st
+    import streamlit.components.v1 as components
+
+    from lettucedetect.models.inference import HallucinationDetector
+
     st.set_page_config(page_title="Lettuce Detective")
 
     st.image(
@@ -50,14 +106,13 @@ def main():
 
     st.title("Let Us Detect Your Hallucinations")
 
-    @st.cache_resource
-    def load_detector():
-        return HallucinationDetector(
-            method="transformer",
-            model_path="output/hallucination_detection_ettin_17m",
-        )
+    model_label = st.sidebar.selectbox("Detector", list(MODEL_OPTIONS))
 
-    detector = load_detector()
+    @st.cache_resource
+    def load_detector(selected_model: str) -> HallucinationDetector:
+        return HallucinationDetector(method="transformer", **MODEL_OPTIONS[selected_model])
+
+    detector = load_detector(model_label)
 
     context = st.text_area(
         "Context",
@@ -82,8 +137,25 @@ def main():
             context=[context], question=question, answer=answer, output_format="spans"
         )
 
+        if any(prediction.get("category") for prediction in predictions):
+            st.markdown(create_legend_html(), unsafe_allow_html=True)
+
         html_content = create_interactive_text(answer, predictions)
         components.html(html_content, height=200)
+
+        if predictions:
+            rows = [
+                {
+                    "start": prediction.get("start"),
+                    "end": prediction.get("end"),
+                    "text": prediction.get("text", answer[prediction["start"] : prediction["end"]]),
+                    "category": prediction.get("category", "untyped"),
+                    "subcategory": prediction.get("subcategory", ""),
+                    "confidence": prediction.get("confidence"),
+                }
+                for prediction in predictions
+            ]
+            st.dataframe(rows, hide_index=True, use_container_width=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_demo_pytest.py
+++ b/tests/test_demo_pytest.py
@@ -1,0 +1,73 @@
+"""Tests for the Streamlit demo's pure HTML renderer."""
+
+from demo.streamlit_demo import CATEGORY_COLORS, DEFAULT_SPAN_COLOR, create_interactive_text
+
+
+def test_create_interactive_text_renders_typed_span() -> None:
+    answer = "The population is 69 million."
+    start = answer.index("69 million")
+    spans = [
+        {
+            "start": start,
+            "end": start + len("69 million"),
+            "text": "69 million",
+            "confidence": 0.9876,
+            "category": "contradiction",
+            "subcategory": "numerical",
+        }
+    ]
+
+    rendered = create_interactive_text(answer, spans)
+
+    assert f"background-color: {CATEGORY_COLORS['contradiction']}" in rendered
+    assert "Category: contradiction" in rendered
+    assert "Subcategory: numerical" in rendered
+    assert "Confidence: 0.988" in rendered
+    assert ">69 million</span>" in rendered
+
+
+def test_create_interactive_text_keeps_binary_span_style() -> None:
+    answer = "Paris has 12 million residents."
+    start = answer.index("12 million")
+    spans = [
+        {
+            "start": start,
+            "end": start + len("12 million"),
+            "text": "12 million",
+            "confidence": 0.75,
+        }
+    ]
+
+    rendered = create_interactive_text(answer, spans)
+
+    assert f"background-color: {DEFAULT_SPAN_COLOR}" in rendered
+    assert "Confidence: 0.750" in rendered
+    assert "Category:" not in rendered
+    assert ">12 million</span>" in rendered
+
+
+def test_create_interactive_text_preserves_multiple_span_order() -> None:
+    answer = "Alpha beta gamma delta."
+    spans = [
+        {
+            "start": answer.index("Alpha"),
+            "end": answer.index("Alpha") + len("Alpha"),
+            "confidence": 0.8,
+            "category": "unsupported_addition",
+            "subcategory": "claim",
+        },
+        {
+            "start": answer.index("gamma"),
+            "end": answer.index("gamma") + len("gamma"),
+            "confidence": 0.9,
+            "category": "fabricated_reference",
+            "subcategory": "entity",
+        },
+    ]
+
+    rendered = create_interactive_text(answer, spans)
+
+    assert rendered.index(">Alpha</span>") < rendered.index(">gamma</span>")
+    assert rendered.count('class="hallucination"') == 2
+    assert f"background-color: {CATEGORY_COLORS['unsupported_addition']}" in rendered
+    assert f"background-color: {CATEGORY_COLORS['fabricated_reference']}" in rendered


### PR DESCRIPTION
## Summary

- replace the demo's developer-local checkpoint with a fresh-clone-compatible v2 encoder cascade
- add a cached sidebar selector for typed and binary models
- color typed spans by taxonomy category and show category, subcategory, and confidence in tooltips
- add a category legend, per-span table, and focused renderer tests for typed, untyped, and multiple spans

## Related issue

Fixes #57

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [x] Tests
- [ ] Refactor or maintenance

## Testing

- [x] `python3 -m ruff format --check demo/streamlit_demo.py tests/test_demo_pytest.py`
- [x] `python3 -m ruff check demo/streamlit_demo.py tests/test_demo_pytest.py`
- [x] `python3 -m pytest tests/test_demo_pytest.py -v` (3 passed)
- [x] `python3 -m py_compile demo/streamlit_demo.py tests/test_demo_pytest.py`
- [x] `git diff --check`
- [ ] `pytest tests/test_inference_pytest.py -v -k "not TestAnswerStartToken"` — collection was attempted but this runner does not have `torch` installed
- [ ] Interactive model-download smoke test — not run locally because the runner lacks Streamlit/model dependencies and has insufficient disk for the model stack

## Checklist

- [x] I kept the PR focused on one change.
- [x] I added or updated tests/docs when needed.
- [x] I checked that no secrets, API keys, or credentials are included.

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).
