### PR TITLE
chore: stabilize CI and clarify roadmap

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,9 +18,9 @@
 
 <!-- List the exact commands you ran. -->
 
-- [ ] `ruff format --check lettucedetect/ tests/`
-- [ ] `ruff check lettucedetect/ tests/ --extend-exclude lettucedetect/integrations/`
-- [ ] `pytest tests/test_inference_pytest.py -v -k "not TestAnswerStartToken"`
+- [ ] `ruff format --check lettucedetect/ lettucedetect_api/ tests/`
+- [ ] `ruff check lettucedetect/ lettucedetect_api/ tests/ --extend-exclude lettucedetect/integrations/`
+- [ ] `python -m pytest`
 - [ ] Other:
 
 ## Checklist

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -22,8 +22,8 @@ jobs:
 
     - name: Lint
       run: |
-        ruff format --check --diff lettucedetect/ tests/
-        ruff check lettucedetect/ tests/ --extend-exclude lettucedetect/integrations/
+        ruff format --no-cache --check --diff lettucedetect/ lettucedetect_api/ tests/
+        ruff check --no-cache lettucedetect/ lettucedetect_api/ tests/ --extend-exclude lettucedetect/integrations/
 
   test:
     runs-on: ubuntu-latest
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.11"
         cache: 'pip'
 
     - name: Install dependencies
@@ -42,5 +42,8 @@ jobs:
         pip install -e ".[dev]"
 
     - name: Test with pytest
+      env:
+        HF_HUB_OFFLINE: "1"
+        TRANSFORMERS_OFFLINE: "1"
       run: |
-        pytest tests/test_inference_pytest.py -v -k "not TestAnswerStartToken"
+        python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,7 +112,10 @@ All notable changes to LettuceDetect are documented here.
 - First trained hallucination detection model (ModernBERT-base, 6 epochs)
 - Token classification for hallucination span detection
 
-[Unreleased]: https://github.com/KRLabsOrg/LettuceDetect/compare/0.1.8...HEAD
+[Unreleased]: https://github.com/KRLabsOrg/LettuceDetect/compare/v0.2.2...HEAD
+[0.2.2]: https://github.com/KRLabsOrg/LettuceDetect/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/KRLabsOrg/LettuceDetect/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/KRLabsOrg/LettuceDetect/compare/0.1.8...v0.2.0
 [0.1.8]: https://github.com/KRLabsOrg/LettuceDetect/compare/0.1.7...0.1.8
 [0.1.7]: https://github.com/KRLabsOrg/LettuceDetect/compare/0.1.6...0.1.7
 [0.1.6]: https://github.com/KRLabsOrg/LettuceDetect/compare/0.1.5...0.1.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for your interest in contributing! This guide will get you up and running
 git clone https://github.com/KRLabsOrg/LettuceDetect.git
 cd LettuceDetect
 
-# Create a virtual environment (Python 3.10+)
+# Create a virtual environment (Python 3.11+)
 python -m venv .venv
 source .venv/bin/activate
 
@@ -30,16 +30,16 @@ We use [Ruff](https://docs.astral.sh/ruff/) for both linting and formatting, wit
 
 ```bash
 # Check formatting
-ruff format --check lettucedetect/ tests/
+ruff format --check lettucedetect/ lettucedetect_api/ tests/
 
 # Auto-format
-ruff format lettucedetect/ tests/
+ruff format lettucedetect/ lettucedetect_api/ tests/
 
 # Lint
-ruff check lettucedetect/ tests/
+ruff check lettucedetect/ lettucedetect_api/ tests/
 
 # Lint with auto-fix
-ruff check --fix lettucedetect/ tests/
+ruff check --fix lettucedetect/ lettucedetect_api/ tests/
 ```
 
 Key conventions:
@@ -51,11 +51,8 @@ Key conventions:
 ## Running tests
 
 ```bash
-# Run the test suite
-pytest tests/test_inference_pytest.py -v
-
-# Skip tests that download models (faster)
-pytest tests/test_inference_pytest.py -v -k "not TestAnswerStartToken"
+# Run the complete network-free unit suite
+python -m pytest
 ```
 
 Test files must follow the naming pattern `test_*_pytest.py`.
@@ -92,9 +89,9 @@ scripts/             # Training, evaluation, and utility scripts
 
 3. **Run lint and tests** before committing:
    ```bash
-   ruff format lettucedetect/ tests/
-   ruff check lettucedetect/ tests/
-   pytest tests/test_inference_pytest.py -v -k "not TestAnswerStartToken"
+   ruff format lettucedetect/ lettucedetect_api/ tests/
+   ruff check lettucedetect/ lettucedetect_api/ tests/
+   python -m pytest
    ```
 
 4. **Open a pull request** against `main`. CI will run lint and tests automatically.

--- a/PUBLIC_ROADMAP.md
+++ b/PUBLIC_ROADMAP.md
@@ -2,37 +2,46 @@
 
 LettuceDetect is maintained and evidence-driven. This roadmap separates near-term release work from research directions, and it intentionally has no delivery dates. Every item links to a GitHub issue where the discussion happens; milestones group them.
 
-## Now: [v0.3 — Real batching, lighter installs](https://github.com/KRLabsOrg/LettuceDetect/milestone/1)
+## Now: [v0.3 — Faster, lighter, consistent inference](https://github.com/KRLabsOrg/LettuceDetect/milestone/1)
 
-The next PyPI release is about making the existing detectors cheaper to install and faster to run, not about new detection methods.
+The next PyPI release is about making the existing detectors more reliable, cheaper to install, and faster to run—not about adding new detection methods.
 
+- [Run the complete network-free unit suite in CI](https://github.com/KRLabsOrg/LettuceDetect/issues/73): every core unit test should be a merge gate, including factory, dataset, and LLM-client tests.
+- [Define evidence aggregation for chunked inference](https://github.com/KRLabsOrg/LettuceDetect/issues/74): benchmark whether evidence in any chunk or every chunk is required before changing the current conservative behavior.
 - [Real batched inference](https://github.com/KRLabsOrg/LettuceDetect/issues/23): `predict_prompt_batch` currently loops one sample at a time; the plan is padded-batch tokenization with a single forward pass.
 - [Lighter installs](https://github.com/KRLabsOrg/LettuceDetect/issues/69): lazy top-level imports so the LLM detector never touches torch. How to slim the default install without breaking existing users is an open design question; input welcome on the issue.
 - [Fix tokens output from the LLM detector](https://github.com/KRLabsOrg/LettuceDetect/issues/65): `output_format="tokens"` should return token-level output, matching the transformer detector.
 - [A `lettucedetect` CLI](https://github.com/KRLabsOrg/LettuceDetect/issues/47) and [a latency/throughput benchmark](https://github.com/KRLabsOrg/LettuceDetect/issues/58): both have contributor PRs in review.
 - [Document `min_confidence` edge cases](https://github.com/KRLabsOrg/LettuceDetect/issues/64): contributor PR in review.
 
-## Next: [Typed spans in the wild](https://github.com/KRLabsOrg/LettuceDetect/milestone/3)
+## Next: [Validation — Typed-span workflows](https://github.com/KRLabsOrg/LettuceDetect/milestone/3)
 
-The detectors already emit typed spans (category and subcategory per detected span); this milestone makes that visible and usable in real workflows.
+The detectors already emit typed spans (category and subcategory per detected span). This milestone tests whether that localization improves real debugging, evaluation, monitoring, and agent workflows.
 
 - [Typed spans in the Streamlit demo](https://github.com/KRLabsOrg/LettuceDetect/issues/57)
 - [Dataset-level hallucination-rate evaluation and reporting](https://github.com/KRLabsOrg/LettuceDetect/issues/56)
 - [A Claude Code hook that flags hallucinations in agent answers](https://github.com/KRLabsOrg/LettuceDetect/issues/50)
+- [A stable HTTP contract for typed spans and detector selection](https://github.com/KRLabsOrg/LettuceDetect/issues/75)
 
-## Exploring: [safety spans and long context](https://github.com/KRLabsOrg/LettuceDetect/milestone/2)
+## Exploring: [transferable span detection](https://github.com/KRLabsOrg/LettuceDetect/milestone/2)
 
 A collaborator playground. These issues are experiments and design discussions, not committed release features or stable APIs. Reproducible comparisons, failure analyses, and short design notes are valuable contributions even when the result is negative.
 
 - [Span-based safety classification](https://github.com/KRLabsOrg/LettuceDetect/issues/43) and [span-level supervision from Aegis 2.0](https://github.com/KRLabsOrg/LettuceDetect/issues/44): extending span detection from hallucination to safety dimensions.
 - [Span-level prompt-injection and jailbreak detection](https://github.com/KRLabsOrg/LettuceDetect/issues/55)
-- [Long-context bidirectional encoders](https://github.com/KRLabsOrg/LettuceDetect/issues/42)
 - [Zero-shot token classification via label conditioning](https://github.com/KRLabsOrg/LettuceDetect/issues/70): GLiNER-style label conditioning, but token-level, so unseen span taxonomies work without retraining.
-- [A rule-based detection tier](https://github.com/KRLabsOrg/LettuceDetect/issues/15): interpretable lexical checks (numbers, dates, entities unsupported by the context) as a zero-cost, torch-free first tier, potentially synthesized from RAGTruth annotations with [RuleChef](https://github.com/KRLabsOrg/rulechef).
+
+## Exploring: [efficient span detection](https://github.com/KRLabsOrg/LettuceDetect/milestone/4)
+
+Experiments on lower-cost and long-context paths. As above, these are not release commitments.
+
+- [Long-context bidirectional encoders](https://github.com/KRLabsOrg/LettuceDetect/issues/42)
+- [A rule-based detection tier](https://github.com/KRLabsOrg/LettuceDetect/issues/15): low-compute lexical checks for unsupported numbers, dates, durations, and entities, with inspectable rule outputs and optional candidate synthesis through [RuleChef](https://github.com/KRLabsOrg/rulechef). Synthesized rules remain hypotheses until they are frozen and evaluated against held-out gold labels.
 
 ## How this roadmap changes
 
 - Items move from Exploring to Now only with evidence: a working prototype, a benchmark result, or a design note that survived discussion.
 - Simpler baselines and negative results can narrow or stop a direction.
 - Anything user-facing lands with documentation and an entry in the changelog.
-- Suggestions belong in issues; the roadmap is updated when milestones change, not on a schedule.
+- Accepted, scoped work belongs in issues. Open product and research questions belong in [Discussions](https://github.com/KRLabsOrg/LettuceDetect/discussions).
+- The roadmap is updated when evidence or milestones change, not on a schedule.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <br><em>Because even AI needs a reality check! 🥬</em>
 </p>
 
-LettuceDetect is a lightweight and efficient tool for detecting hallucinations in Retrieval-Augmented Generation (RAG) systems. It identifies unsupported parts of an answer by comparing it to the provided context. The tool is trained and evaluated on the [RAGTruth](https://aclanthology.org/2024.acl-long.585/) dataset and leverages [ModernBERT](https://github.com/AnswerDotAI/ModernBERT) for English and [EuroBERT](https://huggingface.co/blog/EuroBERT/release) for multilingual support, making it ideal for tasks requiring extensive context windows.
+LettuceDetect is an open span-level grounding verifier for AI outputs. Given source evidence, it localizes unsupported, contradictory, or fabricated parts of RAG answers, coding-agent responses, and tool-grounded outputs. The project includes fast local encoder models as well as generative detectors that can type each detected span.
 
 Our models are inspired from the [Luna](https://aclanthology.org/2025.coling-industry.34/) paper which is an encoder-based model and uses a similar token-level approach.
 
@@ -21,11 +21,10 @@ See the [public roadmap](PUBLIC_ROADMAP.md) for what is landing in the next rele
 
 ## Highlights
 
-- LettuceDetect addresses two critical limitations of existing hallucination detection models:
-  - Context window constraints of traditional encoder-based methods
-  - Computational inefficiency of LLM-based approaches
-- Our models currently **outperform** all other encoder-based and prompt-based models on the RAGTruth dataset and are significantly faster and smaller 
-- Achieves higher score than some fine-tuned LLMs e.g. LLAMA-2-13B presented in [RAGTruth](https://aclanthology.org/2024.acl-long.585/), coming up just short of the LLM fine-tuned in the [RAG-HAT paper](https://aclanthology.org/2024.emnlp-industry.113.pdf)
+- Returns exact character spans instead of only an answer-level clean/flagged verdict.
+- Supports RAG prose, multilingual QA, code-agent answers, and developer-tool output.
+- Offers purpose-built encoder models for local inference and generative models for typed spans.
+- Publishes scoped benchmark results and model limitations in the [benchmark documentation](docs/benchmarks.md) and [model cards](docs/code-hallucination/).
 
 ## 🥬👨‍💻 New (June 2026): code, tool output & agentic workflows
 
@@ -43,6 +42,9 @@ LettuceDetect now detects hallucinations in **coding-agent** answers — grounde
 
 ## 🚀 Latest Updates
 
+- **July 5, 2026** - Released **0.2.2**, fixing `method="llm"` confidence validation and adding a detector-hierarchy regression test.
+- **July 2, 2026** - Released **0.2.1** with `min_confidence`, contributor infrastructure, and packaging fixes.
+- **June 22, 2026** - Released **0.2.0** with code/tool/agentic models, typed spans, the encoder taxonomy cascade, and automatic context chunking. See the [changelog](CHANGELOG.md) for the complete release notes.
 - **August 31, 2025** - Released version **0.1.8**: Added TinyLettuce Ettin models for 17M, 32M, and 68M variants, Hallucination generation pipeline and added RAGFactChecker for triplet-based hallucination detection.
   - See [TinyLettuce Blog Post](https://huggingface.co/blog/adaamko/tinylettuce) for more details.
   - Our collection on Hugging Face: [TinyLettuce](https://huggingface.co/collections/KRLabsOrg/tinylettuce-68b42a66b8b6aaa4bf287bf4)
@@ -168,11 +170,12 @@ The generative model `lettucedect-v2-qwen-2b` produces the same typed spans in a
 
 ## Performance
 
-We've evaluated our models against both encoder-based and LLM-based approaches. The key findings include:
+We've evaluated our models against both encoder-based and LLM-based approaches. Results are specific to the stated model, dataset, split, and metric:
 
-- In English, our model **outperform** all other encoder-based and prompt-based models on the RAGTruth dataset and are significantly faster and smaller 
-- Our multilingual models are better than baseline LLM judges like GPT-4.1-mini
-- Our models are also significantly faster and smaller than the LLM-based judges
+- On the unified 10,698-example v2 test set, Qwen-2B reaches 0.689 span-F1 and mmBERT-base reaches 0.642.
+- On the RAGTruth slice of that same evaluation, Qwen-2B reaches 0.574 span-F1 and mmBERT-base reaches 0.528. These should not be confused with the unified scores.
+- On code-agent answers, Qwen-2B reaches 0.602 span-F1; the released paper and model cards document the benchmark construction and limitations.
+- The original English and multilingual model families have their own evaluation protocols; use their documentation rather than comparing numbers across protocols as one leaderboard.
 
 For detailed performance metrics and evaluations of our models:
 - [English model documentation](docs/README.md)
@@ -344,7 +347,7 @@ For async support use the `LettuceClientAsync` class instead.
 
 ## Community
 
-Join us on [Discord](https://discord.gg/RspnGxJNMa) for questions, ideas, and to get involved. New contributors welcome — check the [`good first issue`](https://github.com/KRLabsOrg/LettuceDetect/issues?q=is%3Aopen+label%3A%22good+first+issue%22) and [`help wanted`](https://github.com/KRLabsOrg/LettuceDetect/issues?q=is%3Aopen+label%3A%22help+wanted%22) issues.
+Use [GitHub Discussions](https://github.com/KRLabsOrg/LettuceDetect/discussions) for use cases, research questions, and proposals that are not yet scoped work. Join us on [Discord](https://discord.gg/RspnGxJNMa) for informal conversation. New contributors can check the [`good first issue`](https://github.com/KRLabsOrg/LettuceDetect/issues?q=is%3Aopen+label%3A%22good+first+issue%22) and [`help wanted`](https://github.com/KRLabsOrg/LettuceDetect/issues?q=is%3Aopen+label%3A%22help+wanted%22) issues; items labeled [`status: claimed`](https://github.com/KRLabsOrg/LettuceDetect/issues?q=is%3Aopen+label%3A%22status%3A+claimed%22) already have active work.
 
 ## License
 

--- a/docs/code-hallucination/model_card_v2_qwen.md
+++ b/docs/code-hallucination/model_card_v2_qwen.md
@@ -212,8 +212,8 @@ specialized methods, so the code/tool sources extend rather than trade off again
 Second only to a fine-tuned 8B, and above the v1 detector, the fine-tuned 13B, Luna, and GPT-4.
 (Our span-level on RAGTruth: P 0.601 / R 0.548 / F1 0.574 / IoU 0.765.)
 
-**PsiloQA** (multilingual) — span IoU. Our generative 2B matches PsiloQA's best fine-tuned
-*encoder* and is far above the strongest LLM judge:
+**PsiloQA** (multilingual) — span IoU. Our generative 2B exceeds the best fine-tuned
+*encoder* reported by PsiloQA and is far above its strongest LLM judge:
 
 | Method (English) | IoU |
 |---|--:|

--- a/docs/code-hallucination/results_generative.md
+++ b/docs/code-hallucination/results_generative.md
@@ -49,10 +49,14 @@ typed and span numbers nearly coincide — one dominant span per sample.)
 Qwen **beats mmBERT on every source**, span- and example-level — including code,
 which the encoder previously won:
 
-| | ALL span_F1 | ALL ex_F1 | code-agent span_F1 | psiloqa IoU |
-|---|--:|--:|--:|--:|
-| mmBERT-base (binary) | 0.572 | 0.862 | 0.508 | 0.627 |
-| **Qwen3.5-2B (SFT)** | **0.689** | **0.921** | **0.602** | **0.687** |
+| | ALL span_F1 | ALL ex_F1 | RAGTruth span_F1 | code-agent span_F1 | psiloqa IoU |
+|---|--:|--:|--:|--:|--:|
+| mmBERT-base (binary) | 0.642 | 0.869 | 0.528 | 0.508 | 0.627 |
+| **Qwen3.5-2B (SFT)** | **0.689** | **0.921** | **0.574** | **0.602** | **0.687** |
+
+The unified `ALL` score and the RAGTruth slice are different measurements. In
+particular, mmBERT-base scores 0.642 across the full unified test set and 0.528
+on its RAGTruth subset.
 
 The decisive factor was the prompt fix (including the user request): the earlier
 generative model, trained on a context-only prompt, scored only 0.383 span-F1 on

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -29,7 +29,7 @@ pip install -e ".[docs]"
 
 ## Requirements
 
-- Python >= 3.10
+- Python >= 3.11
 - PyTorch >= 2.6.0
 - Transformers >= 4.48.3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ lettucedetect = ["prompts/*.txt", "prompts/*.json"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = "test_*_pytest.py"
+addopts = "-v --tb=short --strict-markers"
 
 [tool.ruff]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,45 @@
 """Shared fixtures for pytest tests."""
+
+import pytest
+from tokenizers import Tokenizer
+from tokenizers.models import WordPiece
+from tokenizers.pre_tokenizers import BertPreTokenizer
+from tokenizers.processors import TemplateProcessing
+from transformers import PreTrainedTokenizerFast
+
+
+@pytest.fixture(scope="session")
+def local_wordpiece_tokenizer() -> PreTrainedTokenizerFast:
+    """Build a tiny BERT-style tokenizer without reading from the network."""
+    tokens = [
+        "[PAD]",
+        "[UNK]",
+        "[CLS]",
+        "[SEP]",
+        "[MASK]",
+        "the",
+        "capital",
+        "of",
+        "france",
+        "is",
+        "paris",
+        ".",
+        "short",
+        "answer",
+        "word",
+    ]
+    tokenizer = Tokenizer(WordPiece(vocab={token: index for index, token in enumerate(tokens)}))
+    tokenizer.pre_tokenizer = BertPreTokenizer()
+    tokenizer.post_processor = TemplateProcessing(
+        single="[CLS] $A [SEP]",
+        pair="[CLS] $A [SEP] $B:1 [SEP]:1",
+        special_tokens=[("[CLS]", 2), ("[SEP]", 3)],
+    )
+    return PreTrainedTokenizerFast(
+        tokenizer_object=tokenizer,
+        pad_token="[PAD]",  # noqa: S106 - tokenizer special token, not a credential
+        unk_token="[UNK]",  # noqa: S106 - tokenizer special token, not a credential
+        cls_token="[CLS]",  # noqa: S106 - tokenizer special token, not a credential
+        sep_token="[SEP]",  # noqa: S106 - tokenizer special token, not a credential
+        mask_token="[MASK]",  # noqa: S106 - tokenizer special token, not a credential
+    )

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-testpaths = tests
-python_files = test_*_pytest.py
-python_classes = Test*
-python_functions = test_*
-addopts = -v --tb=short 

--- a/tests/run_pytest.py
+++ b/tests/run_pytest.py
@@ -8,18 +8,7 @@ import pytest
 
 def run_tests():
     """Run pytest tests for the lettucedetect package."""
-    # Run pytest with specified arguments
-    args = [
-        "-v",  # verbose output
-        "--tb=short",  # shorter traceback format
-        "tests/test_inference_pytest.py",  # only run inference tests
-    ]
-
-    # Add any command line arguments
-    args.extend(sys.argv[1:])
-
-    # Run pytest and return the exit code
-    return pytest.main(args)
+    return pytest.main(sys.argv[1:])
 
 
 if __name__ == "__main__":

--- a/tests/test_inference_pytest.py
+++ b/tests/test_inference_pytest.py
@@ -378,16 +378,13 @@ class TestChunking:
 class TestAnswerStartToken:
     """Tests for the answer_start_token fix in prepare_tokenized_input."""
 
-    def test_answer_start_token_basic(self):
+    def test_answer_start_token_basic(self, local_wordpiece_tokenizer):
         """answer_start_token should point to the first answer token."""
-        from transformers import AutoTokenizer
-
-        tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         context = "The capital of France is Paris."
         answer = "Paris is the capital."
 
         _, _, offsets, answer_start = HallucinationDataset.prepare_tokenized_input(
-            tokenizer, context, answer, max_length=512
+            local_wordpiece_tokenizer, context, answer, max_length=512
         )
 
         # answer_start should be within bounds
@@ -396,17 +393,14 @@ class TestAnswerStartToken:
         # The offset at answer_start should be non-zero (actual token, not special)
         assert offsets[answer_start][1].item() > offsets[answer_start][0].item()
 
-    def test_answer_start_token_with_truncation(self):
+    def test_answer_start_token_with_truncation(self, local_wordpiece_tokenizer):
         """answer_start_token should be correct even when context is truncated."""
-        from transformers import AutoTokenizer
-
-        tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
         # Create a very long context that will be truncated at max_length=32
         context = "word " * 200  # ~200 tokens
         answer = "short answer"
 
         encoding, _, offsets, answer_start = HallucinationDataset.prepare_tokenized_input(
-            tokenizer, context, answer, max_length=32
+            local_wordpiece_tokenizer, context, answer, max_length=32
         )
 
         total_len = encoding["input_ids"].shape[1]

--- a/tests/test_llm_client_pytest.py
+++ b/tests/test_llm_client_pytest.py
@@ -335,11 +335,19 @@ class TestLLMDetectorWithInjectedClient:
         assert client.calls[0]["schema"] == PLAIN_SCHEMA
         assert spans == [{"start": 9, "end": 14, "text": "sunny"}]
 
-    def test_include_taxonomy_returns_category_in_spans(self, cache_file):
-        """With include_taxonomy=True, spans carry the LLM's category."""
+    def test_include_taxonomy_returns_category_and_subcategory_in_spans(self, cache_file):
+        """With include_taxonomy=True, spans carry category and subcategory."""
         answer = "The capital of France is Paris and it is sunny."
         response = json.dumps(
-            {"hallucination_list": [{"text": "it is sunny", "category": "unsupported_addition"}]}
+            {
+                "hallucination_list": [
+                    {
+                        "text": "it is sunny",
+                        "category": "unsupported_addition",
+                        "subcategory": "entity",
+                    }
+                ]
+            }
         )
         client = FakeClient(response)
         detector = make_detector(client, cache_file, include_taxonomy=True)
@@ -357,6 +365,7 @@ class TestLLMDetectorWithInjectedClient:
                 "end": answer.index("it is sunny") + len("it is sunny"),
                 "text": "it is sunny",
                 "category": "unsupported_addition",
+                "subcategory": "entity",
             }
         ]
 
@@ -406,6 +415,7 @@ class TestLLMDetectorWithInjectedClient:
                         "confidence": 0.9,
                         "reasoning": "The source says Lisbon is in Portugal.",
                         "category": "contradiction",
+                        "subcategory": "entity",
                     }
                 ]
             }
@@ -423,6 +433,7 @@ class TestLLMDetectorWithInjectedClient:
                 "confidence": 0.9,
                 "reasoning": "The source says Lisbon is in Portugal.",
                 "category": "contradiction",
+                "subcategory": "entity",
             }
         ]
         items = client.calls[0]["schema"]["properties"]["hallucination_list"]["items"]
@@ -430,6 +441,7 @@ class TestLLMDetectorWithInjectedClient:
             "text",
             "reasoning",
             "category",
+            "subcategory",
             "confidence",
             "is_hallucination",
         ]


### PR DESCRIPTION
## Summary

- make all 85 core unit tests network-free and run the complete suite in CI on the declared minimum Python version;
- replace Hub-dependent tokenizer tests with a tiny local tokenizer and update the stale taxonomy schema expectation;
- align contributor commands, Python requirements, release links, and current-version documentation;
- clarify LettuceDetect's span-level grounding-verification thesis and scope benchmark claims by model, split, and metric;
- distinguish mmBERT's 0.642 unified span-F1 from its 0.528 RAGTruth-slice span-F1;
- update the public roadmap for the renamed/split milestones, correctness issues, claimed work, and GitHub Discussions.

This PR does not change detector inference behavior. Chunk aggregation and the HTTP contract remain design/correctness work in #74 and #75.

Closes #73.

## Test evidence

```text
HF_HOME=<empty> HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 python -m pytest
85 passed

python -m ruff format --no-cache --check --diff lettucedetect/ lettucedetect_api/ tests/
57 files already formatted

python -m ruff check --no-cache lettucedetect/ lettucedetect_api/ tests/ --extend-exclude lettucedetect/integrations/
All checks passed
```

## Contribution rights

- [x] I certify that I have the right to submit this code and that it may be distributed under the repository's MIT license.
