### PR TITLE
fix: honor output_format="tokens" in LLMDetector (#65)

### DIFF
--- a/lettucedetect/detectors/llm.py
+++ b/lettucedetect/detectors/llm.py
@@ -49,6 +49,11 @@ _VERIFY_SYSTEM = (
     "You are a strict fact-checker confirming whether flagged spans are truly unsupported."
 )
 
+# Token-level probabilities reported when the LLM gave us no per-span confidence
+# (i.e. include_reasoning=False). Same fixed-constant idea as RAGFactCheckerDetector.
+_HALLUCINATED_TOKEN_PROB = 0.9
+_SUPPORTED_TOKEN_PROB = 0.1
+
 
 class LLMDetector(BaseDetector):
     """LLM-powered hallucination detector."""
@@ -310,6 +315,36 @@ class LLMDetector(BaseDetector):
         return spans
 
     @staticmethod
+    def _convert_to_tokens(answer: str, spans: list[dict]) -> list[dict]:
+        """Project predicted character spans onto the whitespace tokens of ``answer``.
+
+        Emits one ``{"token", "pred", "prob"}`` dict per whitespace-delimited token,
+        matching the token format the other detectors produce
+        (``TransformerDetector._predict_single``, ``RAGFactCheckerDetector._convert_to_tokens``).
+        A token is flagged (``pred=1``) when its character range overlaps any predicted
+        span. ``prob`` uses the overlapping span's ``confidence`` when present (only set
+        with ``include_reasoning=True``), otherwise the fixed constants above.
+
+        :param answer: The answer the spans were matched against.
+        :param spans: Character spans as returned by :meth:`_to_spans`.
+        :returns: One token dict per whitespace token in ``answer``.
+        """
+        tokens = []
+        for match in re.finditer(r"\S+", answer):
+            hit = next(
+                (s for s in spans if s["start"] < match.end() and match.start() < s["end"]),
+                None,
+            )
+            if hit is None:
+                prob = _SUPPORTED_TOKEN_PROB
+            else:
+                prob = hit.get("confidence")
+                if prob is None:
+                    prob = _HALLUCINATED_TOKEN_PROB
+            tokens.append({"token": match.group(), "pred": 0 if hit is None else 1, "prob": prob})
+        return tokens
+
+    @staticmethod
     def _parse_response(raw: str) -> list:
         """Parse and validate the raw LLM response into a hallucination list.
 
@@ -463,11 +498,11 @@ class LLMDetector(BaseDetector):
         :param context: List of passages that were supplied to the LLM / user.
         :param answer: Model-generated answer to inspect.
         :param question: Original question (``None`` for summarisation).
-        :param output_format: ``"spans"`` for character spans.
+        :param output_format: ``"tokens"`` for per-token dicts, ``"spans"`` for character spans.
         :param min_confidence: Drop spans whose ``confidence`` is below this threshold
             (in ``[0, 1]``). Applied on top of the constructor-level ``min_confidence``;
             ``0.0`` keeps every span.
-        :returns: List of spans.
+        :returns: List of spans, or per-token dicts when ``output_format="tokens"``.
         """
         if output_format not in ["tokens", "spans"]:
             raise ValueError(
@@ -477,6 +512,8 @@ class LLMDetector(BaseDetector):
         # Use PromptUtils to format the context and question
         full_prompt = PromptUtils.format_context(context, question, self.lang)
         spans = self._predict(full_prompt, answer)
+        if output_format == "tokens":
+            return self._convert_to_tokens(answer, spans)
         return self._filter_spans_by_confidence(spans, output_format, min_confidence)
 
     def predict_prompt(
@@ -486,10 +523,10 @@ class LLMDetector(BaseDetector):
 
         :param prompt: The prompt string.
         :param answer: The answer string.
-        :param output_format: ``"spans"`` for character spans.
+        :param output_format: ``"tokens"`` for per-token dicts, ``"spans"`` for character spans.
         :param min_confidence: Drop spans below this confidence threshold (``[0, 1]``); applied
             on top of the constructor-level ``min_confidence``.
-        :returns: List of spans.
+        :returns: List of spans, or per-token dicts when ``output_format="tokens"``.
         """
         if output_format not in ["tokens", "spans"]:
             raise ValueError(
@@ -497,6 +534,8 @@ class LLMDetector(BaseDetector):
             )
         self._validate_min_confidence(min_confidence)
         spans = self._predict(prompt, answer)
+        if output_format == "tokens":
+            return self._convert_to_tokens(answer, spans)
         return self._filter_spans_by_confidence(spans, output_format, min_confidence)
 
     def predict_prompt_batch(
@@ -510,10 +549,11 @@ class LLMDetector(BaseDetector):
 
         :param prompts: List of prompt strings.
         :param answers: List of answer strings.
-        :param output_format: ``"spans"`` for character spans.
+        :param output_format: ``"tokens"`` for per-token dicts, ``"spans"`` for character spans.
         :param min_confidence: Drop spans below this confidence threshold (``[0, 1]``); applied
             on top of the constructor-level ``min_confidence``.
-        :returns: List of spans.
+        :returns: One result per input pair: spans, or per-token dicts when
+            ``output_format="tokens"``.
         """
         if output_format not in ["tokens", "spans"]:
             raise ValueError(
@@ -523,7 +563,13 @@ class LLMDetector(BaseDetector):
 
         with ThreadPoolExecutor(max_workers=30) as pool:
             futs = [pool.submit(self._predict, p, a) for p, a in zip(prompts, answers)]
-            return [
-                self._filter_spans_by_confidence(f.result(), output_format, min_confidence)
-                for f in futs
-            ]
+            results = []
+            for answer, fut in zip(answers, futs):
+                spans = fut.result()
+                if output_format == "tokens":
+                    results.append(self._convert_to_tokens(answer, spans))
+                else:
+                    results.append(
+                        self._filter_spans_by_confidence(spans, output_format, min_confidence)
+                    )
+            return results

--- a/tests/test_llm_detector_pytest.py
+++ b/tests/test_llm_detector_pytest.py
@@ -1,0 +1,150 @@
+"""Pytest tests for LLMDetector token output (``output_format="tokens"``).
+
+Regression coverage for the bug where the LLM detector validated
+``output_format="tokens"`` but returned span dicts unchanged. Every prediction
+entry point is exercised through an injected fake client, so the tests never hit
+the network and ``cache_file`` points into ``tmp_path`` to keep the on-disk cache
+untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lettucedetect.detectors.llm import LLMDetector
+from lettucedetect.detectors.llm_client import LLMClient
+
+TOKEN_KEYS = {"token", "pred", "prob"}
+
+
+class FakeClient(LLMClient):
+    """An LLMClient that returns a canned JSON response without any network call."""
+
+    def __init__(self, response: str) -> None:
+        """Store the response the fake client should hand back."""
+        self.response = response
+
+    def complete(self, system, user, model, temperature, schema) -> str:
+        """Ignore the request and return the canned response."""
+        return self.response
+
+
+@pytest.fixture
+def cache_file(tmp_path):
+    """Temp cache path so the default on-disk cache is never touched."""
+    return str(tmp_path / "cache.json")
+
+
+def make_detector(response, cache_file, **kwargs):
+    return LLMDetector(client=FakeClient(response), cache_file=cache_file, **kwargs)
+
+
+def is_token_list(result):
+    return bool(result) and all(set(item) == TOKEN_KEYS for item in result)
+
+
+class TestTokenOutput:
+    """LLMDetector must honour output_format="tokens" on every entry point."""
+
+    def test_predict_returns_token_dicts_not_spans(self, cache_file):
+        """predict() with tokens yields {token, pred, prob} dicts, never spans."""
+        answer = "The population of France is 69 million."
+        detector = make_detector('{"hallucination_list": ["69 million"]}', cache_file)
+
+        result = detector.predict(
+            context=["France has about 67 million people."],
+            answer=answer,
+            question="What is the population of France?",
+            output_format="tokens",
+        )
+
+        assert is_token_list(result)
+        assert [t["token"] for t in result] == answer.split()
+        assert all("start" not in t and "end" not in t for t in result)
+        assert any(t["pred"] == 1 and "69" in t["token"] for t in result)
+
+    def test_predict_prompt_returns_token_dicts(self, cache_file):
+        """predict_prompt() routes tokens through the same conversion."""
+        answer = "Lisbon is the capital of Spain."
+        detector = make_detector('{"hallucination_list": ["Spain"]}', cache_file)
+
+        result = detector.predict_prompt("some prompt", answer, output_format="tokens")
+
+        assert is_token_list(result)
+        assert [t["token"] for t in result] == answer.split()
+        assert any(t["pred"] == 1 and "Spain" in t["token"] for t in result)
+
+    def test_predict_prompt_batch_returns_token_lists(self, cache_file):
+        """Batch tokens align to each answer independently, one list per pair."""
+        detector = make_detector('{"hallucination_list": ["wrong"]}', cache_file)
+        prompts = ["p1", "p2"]
+        answers = ["this is wrong here", "all correct"]
+
+        results = detector.predict_prompt_batch(prompts, answers, output_format="tokens")
+
+        assert len(results) == 2
+        assert [t["token"] for t in results[0]] == answers[0].split()
+        assert [t["token"] for t in results[1]] == answers[1].split()
+        # "wrong" is only present in the first answer; the second flags nothing.
+        assert any(t["pred"] == 1 for t in results[0])
+        assert all(t["pred"] == 0 for t in results[1])
+
+    def test_supported_tokens_use_low_constant_prob(self, cache_file):
+        """Tokens outside any span get pred=0 and the supported-prob constant."""
+        answer = "Everything here is fine."
+        detector = make_detector('{"hallucination_list": []}', cache_file)
+
+        result = detector.predict_prompt("p", answer, output_format="tokens")
+
+        assert all(t["pred"] == 0 and t["prob"] == 0.1 for t in result)
+
+    def test_flagged_token_prob_uses_span_confidence(self, cache_file):
+        """When the span carries a confidence, flagged tokens report it as prob."""
+        answer = "The tower is 900 meters tall."
+        detector = make_detector(
+            '{"hallucination_list": [{"text": "900 meters", "confidence": 0.87}]}',
+            cache_file,
+        )
+
+        result = detector.predict_prompt("p", answer, output_format="tokens")
+
+        flagged = [t for t in result if t["pred"] == 1]
+        assert flagged and all(t["prob"] == 0.87 for t in flagged)
+
+    def test_flagged_token_prob_defaults_without_confidence(self, cache_file):
+        """No confidence on the span falls back to the hallucinated-prob constant."""
+        answer = "The capital of France is Berlin."
+        detector = make_detector('{"hallucination_list": ["Berlin"]}', cache_file)
+
+        result = detector.predict_prompt("p", answer, output_format="tokens")
+
+        flagged = [t for t in result if t["pred"] == 1]
+        assert flagged and all(t["prob"] == 0.9 for t in flagged)
+
+    def test_min_confidence_does_not_turn_tokens_into_spans(self, cache_file):
+        """min_confidence stays inapplicable to tokens; the shape is still tokens."""
+        answer = "The number is 42 exactly."
+        detector = make_detector('{"hallucination_list": ["42"]}', cache_file)
+
+        result = detector.predict_prompt("p", answer, output_format="tokens", min_confidence=0.5)
+
+        assert is_token_list(result)
+
+
+class TestSpansUnaffected:
+    """The spans path must behave exactly as before."""
+
+    def test_spans_output_unchanged(self, cache_file):
+        """output_format="spans" still returns character-offset spans."""
+        answer = "Lisbon is the capital of Spain."
+        detector = make_detector('{"hallucination_list": ["Spain"]}', cache_file)
+
+        spans = detector.predict_prompt("p", answer, output_format="spans")
+
+        assert spans == [
+            {
+                "start": answer.index("Spain"),
+                "end": answer.index("Spain") + len("Spain"),
+                "text": "Spain",
+            }
+        ]


### PR DESCRIPTION
## Summary

`LLMDetector` validated `output_format="tokens"` but every entry point returned the raw span dicts from `_predict`, so callers asking for tokens got spans back. And because span filtering is skipped for token output, passing `min_confidence` alongside it silently did nothing.

I went with Option A (actually implement token output) instead of making the detector spans-only. The facade defaults to `output_format="tokens"`, so `HallucinationDetector(method="llm").predict(...)` would otherwise break by default, and this keeps the LLM detector in line with the other detectors.

What changed:

- Added `_convert_to_tokens`, which maps predicted character spans onto whitespace tokens (`{token, pred, prob}`), the same way `RAGFactCheckerDetector` does it. A token is flagged when its char range overlaps a predicted span. `prob` uses the span `confidence` when it's present (only set with `include_reasoning=True`), otherwise a fixed constant.
- Routed `predict` / `predict_prompt` / `predict_prompt_batch` through it before the confidence filter.
- Added tests in `tests/test_llm_detector_pytest.py` covering all three entry points. The `spans` path is untouched.

## Related issue

Closes #65.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Documentation
- [ ] Tests
- [ ] Refactor or maintenance

## Testing

- [x] `ruff format --check lettucedetect/ lettucedetect_api/ tests/`
- [x] `ruff check lettucedetect/ lettucedetect_api/ tests/ --extend-exclude lettucedetect/integrations/`
- [x] `python -m pytest`
- [ ] Other:

## Checklist

- [x] I kept the PR focused on one change.
- [x] I added or updated tests/docs when needed.
- [x] I checked that no secrets, API keys, or credentials are included.

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).
