### PR TITLE
docs: note min_confidence isn't applied to tokens output in LLMDetector

### DIFF
--- a/lettucedetect/detectors/llm.py
+++ b/lettucedetect/detectors/llm.py
@@ -501,7 +501,8 @@ class LLMDetector(BaseDetector):
         :param output_format: ``"tokens"`` for per-token dicts, ``"spans"`` for character spans.
         :param min_confidence: Drop spans whose ``confidence`` is below this threshold
             (in ``[0, 1]``). Applied on top of the constructor-level ``min_confidence``;
-            ``0.0`` keeps every span.
+            ``0.0`` keeps every span. Only affects ``output_format="spans"`` — token
+            output is returned unfiltered.
         :returns: List of spans, or per-token dicts when ``output_format="tokens"``.
         """
         if output_format not in ["tokens", "spans"]:
@@ -525,7 +526,8 @@ class LLMDetector(BaseDetector):
         :param answer: The answer string.
         :param output_format: ``"tokens"`` for per-token dicts, ``"spans"`` for character spans.
         :param min_confidence: Drop spans below this confidence threshold (``[0, 1]``); applied
-            on top of the constructor-level ``min_confidence``.
+            on top of the constructor-level ``min_confidence``. Ignored when
+            ``output_format="tokens"``.
         :returns: List of spans, or per-token dicts when ``output_format="tokens"``.
         """
         if output_format not in ["tokens", "spans"]:
@@ -551,7 +553,7 @@ class LLMDetector(BaseDetector):
         :param answers: List of answer strings.
         :param output_format: ``"tokens"`` for per-token dicts, ``"spans"`` for character spans.
         :param min_confidence: Drop spans below this confidence threshold (``[0, 1]``); applied
-            on top of the constructor-level ``min_confidence``.
+            on top of the constructor-level ``min_confidence``. Not applied to token output.
         :returns: One result per input pair: spans, or per-token dicts when
             ``output_format="tokens"``.
         """


### PR DESCRIPTION
## Summary

Small docs follow-up to #80. When `output_format="tokens"`, `LLMDetector` converts spans to tokens before the confidence filter runs, so `min_confidence` has no effect on token output. The `:param min_confidence:` docstrings on `predict`, `predict_prompt`, and `predict_prompt_batch` didn't mention that, so I added a short note to each. No behavior change.

This is the optional docstring nit @adaamko raised in the #80 review.

## Related issue

Follow-up to #80 (which closed #65).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Tests
- [ ] Refactor or maintenance

## Testing

Docstring-only change, no code paths touched.

- [ ] `ruff format --check lettucedetect/ lettucedetect_api/ tests/`
- [ ] `ruff check lettucedetect/ lettucedetect_api/ tests/ --extend-exclude lettucedetect/integrations/`
- [ ] `python -m pytest`
- [x] Other: `python -m py_compile` on the file passes; changed lines are well under the 100-char limit. Leaving lint/pytest for CI.

## Checklist

- [x] I kept the PR focused on one change.
- [x] I added or updated tests/docs when needed.
- [x] I checked that no secrets, API keys, or credentials are included.

## Rights & sign-off (required)

- [x] I certify that I have the right to submit this code and that it may be
      distributed under the repository's MIT license
      (see [CONTRIBUTING](../CONTRIBUTING.md#contribution-rights)).
