### PR TITLE
fix: correct published model ids in CLI help and docs

### DIFF
--- a/docs/getting-started/models.md
+++ b/docs/getting-started/models.md
@@ -14,14 +14,19 @@ A unified family trained on the [code + tool-output + prose benchmark](https://h
 
 | Model | Base | Max Tokens | Example F1 | Span F1 |
 |-------|------|-----------|-----------|---------|
-| [lettucedetect-base-modernbert-en-v1](https://huggingface.co/KRLabsOrg/lettucedetect-base-modernbert-en-v1) | ModernBERT-base | 4K | 76.8% | SOTA |
-| [lettucedetect-large-modernbert-en-v1](https://huggingface.co/KRLabsOrg/lettucedetect-large-modernbert-en-v1) | ModernBERT-large | 4K | 79.2% | SOTA |
+| [lettucedect-base-modernbert-en-v1](https://huggingface.co/KRLabsOrg/lettucedect-base-modernbert-en-v1) | ModernBERT-base | 4K | 76.8% | SOTA |
+| [lettucedect-large-modernbert-en-v1](https://huggingface.co/KRLabsOrg/lettucedect-large-modernbert-en-v1) | ModernBERT-large | 4K | 79.2% | SOTA |
 
 ## Multilingual Models
 
-| Model | Base | Languages | Max Tokens |
+One checkpoint per language, in two sizes:
+
+| Model family | Base | Languages | Max Tokens |
 |-------|------|-----------|-----------|
-| [lettucedetect-base-eurobert-multilingual-v1](https://huggingface.co/KRLabsOrg/lettucedetect-base-eurobert-multilingual-v1) | EuroBERT-210M | en, de, fr, es, it, pl, cn | 8K |
+| `lettucedect-210m-eurobert-<lang>-v1` | EuroBERT-210M | de, fr, es, it, pl, cn | 8K |
+| `lettucedect-610m-eurobert-<lang>-v1` | EuroBERT-610M | de, fr, es, it, pl, cn | 8K |
+
+English is covered by the ModernBERT models above. See the [multilingual collection on Hugging Face](https://huggingface.co/collections/KRLabsOrg/multilingual-hallucination-detection-682a2549c18ecd32689231ce) for every checkpoint. The EuroBERT models load remote code that requires `transformers<5`.
 
 ## TinyLettuce (Distilled)
 
@@ -34,7 +39,7 @@ from lettucedetect.models.inference import HallucinationDetector
 
 detector = HallucinationDetector(
     method="transformer",
-    model_path="KRLabsOrg/lettucedetect-large-modernbert-en-v1"
+    model_path="KRLabsOrg/lettucedect-large-modernbert-en-v1"
 )
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,7 +8,7 @@ from lettucedetect.models.inference import HallucinationDetector
 # Load a pre-trained model
 detector = HallucinationDetector(
     method="transformer",
-    model_path="KRLabsOrg/lettucedetect-base-modernbert-en-v1"
+    model_path="KRLabsOrg/lettucedect-base-modernbert-en-v1"
 )
 
 # Provide context, question, and answer
@@ -85,9 +85,9 @@ print([{"text": answer[start:end], "start": start, "end": end} for start, end in
 
 | Model | Language | Context | Size |
 |-------|----------|---------|------|
-| `KRLabsOrg/lettucedetect-base-modernbert-en-v1` | English | 4K | 149M |
-| `KRLabsOrg/lettucedetect-large-modernbert-en-v1` | English | 4K | 395M |
-| `KRLabsOrg/lettucedetect-base-eurobert-multilingual-v1` | 7 languages | 8K | 210M |
+| `KRLabsOrg/lettucedect-base-modernbert-en-v1` | English | 4K | 149M |
+| `KRLabsOrg/lettucedect-large-modernbert-en-v1` | English | 4K | 395M |
+| `KRLabsOrg/lettucedect-210m-eurobert-<lang>-v1` | de, fr, es, it, pl, cn | 8K | 210M |
 | `KRLabsOrg/lettucedect-v2-qwen-2b` | code / tool / prose | — | 2B |
 | `KRLabsOrg/lettucedect-v2-mmbert-base` | code / tool / prose | 8K | 307M |
 

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -12,7 +12,7 @@ python scripts/start_api.py dev
 python scripts/start_api.py prod
 
 # Custom model
-python scripts/start_api.py dev --model KRLabsOrg/lettucedetect-large-modernbert-en-v1
+python scripts/start_api.py dev --model KRLabsOrg/lettucedect-large-modernbert-en-v1
 ```
 
 ## Python Client

--- a/docs/guide/detection-methods.md
+++ b/docs/guide/detection-methods.md
@@ -9,7 +9,7 @@ Fine-tuned encoder models that classify each token in the answer as supported or
 ```python
 detector = HallucinationDetector(
     method="transformer",
-    model_path="KRLabsOrg/lettucedetect-large-modernbert-en-v1"
+    model_path="KRLabsOrg/lettucedect-large-modernbert-en-v1"
 )
 ```
 

--- a/docs/guide/integrations.md
+++ b/docs/guide/integrations.md
@@ -12,7 +12,7 @@ from lettucedetect.models.inference import HallucinationDetector
 # Create detector
 detector = HallucinationDetector(
     method="transformer",
-    model_path="KRLabsOrg/lettucedetect-base-modernbert-en-v1"
+    model_path="KRLabsOrg/lettucedect-base-modernbert-en-v1"
 )
 
 # Use in your LangChain pipeline
@@ -41,7 +41,7 @@ from lettucedetect.models.inference import HallucinationDetector
 
 detector = HallucinationDetector(
     method="transformer",
-    model_path="KRLabsOrg/lettucedetect-base-modernbert-en-v1"
+    model_path="KRLabsOrg/lettucedect-base-modernbert-en-v1"
 )
 
 # After your RAG pipeline generates an answer:

--- a/docs/guide/multilingual.md
+++ b/docs/guide/multilingual.md
@@ -1,29 +1,35 @@
 # Multilingual Support
 
-LettuceDetect supports hallucination detection in multiple languages via EuroBERT-based models.
+LettuceDetect supports hallucination detection in multiple languages with one checkpoint per language.
 
 ## Supported Languages
 
 | Language | Code | Model |
 |----------|------|-------|
-| English | en | ModernBERT + EuroBERT |
-| German | de | EuroBERT |
-| French | fr | EuroBERT |
-| Spanish | es | EuroBERT |
-| Italian | it | EuroBERT |
-| Polish | pl | EuroBERT |
-| Chinese | cn | EuroBERT |
-| Hungarian | hu | EuroBERT |
+| English | en | [lettucedect-base-modernbert-en-v1](https://huggingface.co/KRLabsOrg/lettucedect-base-modernbert-en-v1) (ModernBERT) |
+| German | de | [lettucedect-210m-eurobert-de-v1](https://huggingface.co/KRLabsOrg/lettucedect-210m-eurobert-de-v1) (EuroBERT) |
+| French | fr | [lettucedect-210m-eurobert-fr-v1](https://huggingface.co/KRLabsOrg/lettucedect-210m-eurobert-fr-v1) (EuroBERT) |
+| Spanish | es | [lettucedect-210m-eurobert-es-v1](https://huggingface.co/KRLabsOrg/lettucedect-210m-eurobert-es-v1) (EuroBERT) |
+| Italian | it | [lettucedect-210m-eurobert-it-v1](https://huggingface.co/KRLabsOrg/lettucedect-210m-eurobert-it-v1) (EuroBERT) |
+| Polish | pl | [lettucedect-210m-eurobert-pl-v1](https://huggingface.co/KRLabsOrg/lettucedect-210m-eurobert-pl-v1) (EuroBERT) |
+| Chinese | cn | [lettucedect-210m-eurobert-cn-v1](https://huggingface.co/KRLabsOrg/lettucedect-210m-eurobert-cn-v1) (EuroBERT) |
+| Hungarian | hu | [lettucedect-mmbert-base-hu-v1](https://huggingface.co/KRLabsOrg/lettucedect-mmbert-base-hu-v1) (mmBERT) |
+
+The EuroBERT models also come in a larger, more accurate 610M variant (`lettucedect-610m-eurobert-<lang>-v1`), and Hungarian in a smaller one (`lettucedect-mmbert-small-hu-v1`). See the [multilingual collection on Hugging Face](https://huggingface.co/collections/KRLabsOrg/multilingual-hallucination-detection-682a2549c18ecd32689231ce).
 
 ## Usage
+
+Pick the checkpoint for your language and pass the language code:
 
 ```python
 from lettucedetect.models.inference import HallucinationDetector
 
 detector = HallucinationDetector(
     method="transformer",
-    model_path="KRLabsOrg/lettucedetect-base-eurobert-multilingual-v1"
+    model_path="KRLabsOrg/lettucedect-210m-eurobert-de-v1",
+    lang="de",
+    trust_remote_code=True,
 )
 ```
 
-The multilingual model handles all supported languages with a single checkpoint. No language detection or switching needed.
+> **Note:** the EuroBERT models load remote code that is not yet compatible with transformers 5.x; install `pip install "transformers>=4.48.3,<5"` when using them. ModernBERT and mmBERT models are unaffected.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ from lettucedetect.models.inference import HallucinationDetector
 
 detector = HallucinationDetector(
     method="transformer",
-    model_path="KRLabsOrg/lettucedetect-base-modernbert-en-v1"
+    model_path="KRLabsOrg/lettucedect-base-modernbert-en-v1"
 )
 
 contexts = ["The capital of France is Paris. The population is 67 million."]

--- a/lettucedetect/cli.py
+++ b/lettucedetect/cli.py
@@ -6,7 +6,7 @@ run hallucination detection from a terminal without writing Python.
 
 Example usage::
 
-    lettucedetect --model KRLabsOrg/lettucedetect-base-modernbert-en-v1 \
+    lettucedetect --model KRLabsOrg/lettucedect-base-modernbert-en-v1 \
         --context context.txt \
         --question "Who founded Wikipedia?" \
         --answer answer.txt \
@@ -14,7 +14,7 @@ Example usage::
 
     # Read context from stdin, answer from a file
     echo "Paris is the capital of France." | \
-        lettucedetect --model KRLabsOrg/lettucedetect-base-modernbert-en-v1 \
+        lettucedetect --model KRLabsOrg/lettucedect-base-modernbert-en-v1 \
         --context - --answer answer.txt --format spans
 """
 
@@ -64,7 +64,7 @@ def _build_parser() -> argparse.ArgumentParser:
         epilog="""
 examples:
   # Use files
-  lettucedetect --model KRLabsOrg/lettucedetect-base-modernbert-en-v1 \\
+  lettucedetect --model KRLabsOrg/lettucedect-base-modernbert-en-v1 \\
       --context context.txt --answer answer.txt --format spans
 
   # Pass text inline
@@ -75,7 +75,7 @@ examples:
       --format spans
 
   # Read context from stdin
-  cat context.txt | lettucedetect --model KRLabsOrg/lettucedetect-base-modernbert-en-v1 \\
+  cat context.txt | lettucedetect --model KRLabsOrg/lettucedect-base-modernbert-en-v1 \\
       --context - --answer answer.txt --format spans
 """,
     )
@@ -86,7 +86,7 @@ examples:
         metavar="MODEL",
         help=(
             "Model to use. For --method transformer: a HuggingFace model ID or local "
-            "path (e.g. KRLabsOrg/lettucedetect-base-modernbert-en-v1). For --method llm: "
+            "path (e.g. KRLabsOrg/lettucedect-base-modernbert-en-v1). For --method llm: "
             "an LLM model name (e.g. gpt-4.1-mini)."
         ),
     )


### PR DESCRIPTION
## What

The published v1 models on the Hub use the `lettucedect-` slug spelling (same as the v2 repos): `KRLabsOrg/lettucedetect-base-modernbert-en-v1` and friends return 404. This PR fixes every reference:

- `lettucedetect/cli.py`: the example model id in the module docstring, epilog, and `--model` help (introduced in #59, where review asked for the wrong spelling — verified against the Hub this time: only the `lettucedect-` form resolves).
- Docs (`index`, `quickstart`, `models`, `guide/api`, `guide/integrations`, `guide/detection-methods`): same correction.
- `docs/getting-started/models.md`, `quickstart.md`, `guide/multilingual.md`: `lettucedetect-base-eurobert-multilingual-v1` does not exist; the real multilingual models are one checkpoint per language (`lettucedect-{210m,610m}-eurobert-<lang>-v1`, Hungarian via mmBERT). Tables and the usage example now reflect that, including the `lang`/`trust_remote_code` arguments and the `transformers<5` note.

## Checklist

- [x] Verified every referenced model id resolves on the Hub (`api/models` 200).

- [x] I certify that I have the right to submit this code and that it may be distributed under the repository's MIT license