### PR TITLE
docs: document min_confidence edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,22 @@ The model can output predictions in two formats:
 }]
 ```
 
+Use `min_confidence` with span output to drop predictions below a threshold:
+
+```python
+detector.predict(
+    context=contexts,
+    question=question,
+    answer=answer,
+    output_format="spans",
+    min_confidence=0.8,
+)
+```
+
+For transformer detectors, emitted hallucination spans already have
+confidence values of at least `0.5`, so thresholds below `0.5` are no-ops;
+higher thresholds raise that floor.
+
 ### Token Format
 ```python
 [{

--- a/lettucedetect/detectors/rag_fact_checker.py
+++ b/lettucedetect/detectors/rag_fact_checker.py
@@ -54,6 +54,8 @@ class RAGFactCheckerDetector(BaseDetector):
         :param question: Question (optional)
         :param output_format: "tokens", "spans", or "detailed"
         :param min_confidence: Drop ``"spans"`` below this confidence threshold (``[0, 1]``).
+            Does not filter ``output_format="detailed"``; detailed output returns
+            the unfiltered spans, triplets, and fact-check results.
         :param kwargs: Additional arguments
 
         :return: List of predictions in lettuceDetect format, or dict for detailed format


### PR DESCRIPTION
## What

Folds in the verified content of #66 (author unresponsive since Jul 10 after two pings; commit co-authored to preserve credit): the README gains a `min_confidence` span-output example plus a note about the transformer detectors' >=0.5 confidence floor, and the RAGFactChecker `predict` docstring notes that `detailed` output is returned unfiltered. All three claims were verified against the code during the #66 review.

Closes #64

## Checklist

- [x] Docs-only change.

- [x] I certify that I have the right to submit this code and that it may be distributed under the repository's MIT license