### PR TITLE
fix: localize repeated LLM spans distinctly

### DIFF
--- a/lettucedetect/detectors/llm.py
+++ b/lettucedetect/detectors/llm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from string import Template
@@ -43,7 +44,9 @@ _RESPONSE_FORMAT = """**Return** a JSON object following *exactly* this schema
    `{"hallucination_list": ["substring1", "substring2", …]}`
 
    Each substring must be copied **verbatim** from the answer — an exact,
-   character-for-character match. If none are found, return `{"hallucination_list": []}`."""
+   character-for-character match. List substrings in answer order and include a
+   repeated substring at most once per distinct occurrence. If none are found,
+   return `{"hallucination_list": []}`."""
 
 _VERIFY_SYSTEM = (
     "You are a strict fact-checker confirming whether flagged spans are truly unsupported."
@@ -198,7 +201,10 @@ class LLMDetector(BaseDetector):
             return _RESPONSE_FORMAT
 
         example: dict = {"text": "substring1"}
-        notes = ['- "text" must be an exact substring of the answer.']
+        notes = [
+            '- "text" must be an exact substring of the answer and items must be listed in answer order.',
+            "- For repeated substrings, return at most one item per distinct occurrence.",
+        ]
         if self.include_reasoning:
             example["reasoning"] = "compare the span against the source before judging it"
             notes.append(
@@ -273,7 +279,9 @@ class LLMDetector(BaseDetector):
         )
 
     @staticmethod
-    def _to_spans(items: list[str | dict], answer: str, min_confidence: float = 0.0) -> list[dict]:
+    def _to_spans(
+        items: Sequence[str | dict], answer: str, min_confidence: float = 0.0
+    ) -> list[dict]:
         """Convert hallucinated items to a list of spans.
 
         Items the model self-rejected (``is_hallucination`` is False) or scored
@@ -288,6 +296,7 @@ class LLMDetector(BaseDetector):
         :returns: List of spans.
         """
         spans = []
+        reserved: list[tuple[int, int]] = []
         for item in items:
             if not isinstance(item, (str, dict)):
                 logger.warning("Skipping malformed hallucination item: %r", item)
@@ -295,17 +304,31 @@ class LLMDetector(BaseDetector):
             sub = item.get("text") if isinstance(item, dict) else item
             if not sub:
                 continue
+
+            match = next(
+                (
+                    candidate
+                    for candidate in re.finditer(re.escape(sub), answer)
+                    if all(
+                        candidate.end() <= start or end <= candidate.start()
+                        for start, end in reserved
+                    )
+                ),
+                None,
+            )
+            if not match:
+                logger.debug(
+                    "Dropping span not found as an unused verbatim answer occurrence: %r", sub
+                )
+                continue
+            reserved.append((match.start(), match.end()))
+
             if isinstance(item, dict):
                 if item.get("is_hallucination") is False:
                     continue
                 confidence = item.get("confidence")
                 if confidence is not None and confidence < min_confidence:
                     continue
-            # Use regex for more reliable matching
-            match = re.search(re.escape(sub), answer)
-            if not match:
-                logger.debug("Dropping span not found verbatim in answer: %r", sub)
-                continue
             span = {"start": match.start(), "end": match.end(), "text": sub}
             if isinstance(item, dict):
                 for key in ("confidence", "reasoning", "category", "subcategory"):

--- a/tests/test_llm_detector_pytest.py
+++ b/tests/test_llm_detector_pytest.py
@@ -131,6 +131,99 @@ class TestTokenOutput:
         assert is_token_list(result)
 
 
+class TestRepeatedSpanLocalization:
+    """Repeated returned strings should localize to distinct answer occurrences."""
+
+    def test_duplicate_strings_use_distinct_occurrences(self):
+        """Identical span strings reserve left-to-right non-overlapping matches."""
+        answer = "Paris is mentioned; Paris is repeated."
+
+        spans = LLMDetector._to_spans(["Paris", "Paris"], answer)
+
+        assert spans == [
+            {"start": 0, "end": 5, "text": "Paris"},
+            {"start": 20, "end": 25, "text": "Paris"},
+        ]
+
+    def test_dict_metadata_stays_with_corresponding_occurrence(self):
+        """Metadata belongs to the occurrence reserved by the matching item."""
+        answer = "Paris is mentioned; Paris is repeated."
+        items = [
+            {"text": "Paris", "confidence": 0.41, "category": "unsupported"},
+            {"text": "Paris", "confidence": 0.92, "reasoning": "second mention"},
+        ]
+
+        spans = LLMDetector._to_spans(items, answer)
+
+        assert spans[0] == {
+            "start": 0,
+            "end": 5,
+            "text": "Paris",
+            "confidence": 0.41,
+            "category": "unsupported",
+        }
+        assert spans[1] == {
+            "start": 20,
+            "end": 25,
+            "text": "Paris",
+            "confidence": 0.92,
+            "reasoning": "second mention",
+        }
+
+    def test_filtered_items_still_reserve_occurrences(self):
+        """Rejected or low-confidence earlier items do not shift later offsets."""
+        answer = "Paris is mentioned; Paris is repeated."
+        items = [
+            {"text": "Paris", "confidence": 0.2},
+            {"text": "Paris", "confidence": 0.9},
+        ]
+
+        spans = LLMDetector._to_spans(items, answer, min_confidence=0.5)
+
+        assert spans == [{"start": 20, "end": 25, "text": "Paris", "confidence": 0.9}]
+
+    def test_rejected_items_still_reserve_occurrences(self):
+        """Self-rejected items reserve their occurrence before being dropped."""
+        answer = "Paris is mentioned; Paris is repeated."
+        items = [
+            {"text": "Paris", "is_hallucination": False},
+            {"text": "Paris", "confidence": 0.9},
+        ]
+
+        spans = LLMDetector._to_spans(items, answer)
+
+        assert spans == [{"start": 20, "end": 25, "text": "Paris", "confidence": 0.9}]
+
+    def test_extra_items_do_not_duplicate_offsets(self):
+        """More repeated items than occurrences are skipped instead of duplicated."""
+        answer = "Paris is mentioned; Paris is repeated."
+
+        spans = LLMDetector._to_spans(["Paris", "Paris", "Paris"], answer)
+
+        assert spans == [
+            {"start": 0, "end": 5, "text": "Paris"},
+            {"start": 20, "end": 25, "text": "Paris"},
+        ]
+
+    def test_single_ambiguous_item_keeps_first_match(self):
+        """A single text-only repeated item keeps the documented first-match fallback."""
+        answer = "Paris is mentioned; Paris is repeated."
+
+        spans = LLMDetector._to_spans(["Paris"], answer)
+
+        assert spans == [{"start": 0, "end": 5, "text": "Paris"}]
+
+    def test_token_output_flags_repeated_occurrences(self, cache_file):
+        """Token projection flags both repeated occurrences end to end."""
+        answer = "Paris is mentioned; Paris is repeated."
+        detector = make_detector('{"hallucination_list": ["Paris", "Paris"]}', cache_file)
+
+        tokens = detector.predict_prompt("p", answer, output_format="tokens")
+
+        flagged = [token["token"] for token in tokens if token["pred"] == 1]
+        assert flagged == ["Paris", "Paris"]
+
+
 class TestSpansUnaffected:
     """The spans path must behave exactly as before."""
 


### PR DESCRIPTION
## Summary
- Map repeated LLM-returned span strings to distinct unused answer occurrences in left-to-right order.
- Reserve occurrences before applying `is_hallucination` and confidence filters so later accepted items keep stable offsets.
- Update generic LLM response instructions to ask for answer-order, one item per distinct occurrence.
- Add network-free regression tests for repeated strings, metadata preservation, filtering, duplicate overflow, first-match fallback, and token projection.

## Why
The generic LLM judge path used a fresh first-match search for every returned substring. When the model returned the same text more than once, all items collapsed onto the first occurrence, so later repeated hallucinations were never represented in spans or token output.

Fixes #85.

## Test plan
- [x] `python3 -m pytest tests/test_llm_detector_pytest.py::TestRepeatedSpanLocalization -q`
- [x] `python3 tests/run_pytest.py -q` — 149 passed
- [x] `ruff check lettucedetect/detectors/llm.py tests/test_llm_detector_pytest.py`
- [x] `git diff --check`


- [x] I certify that I have the right to submit this code.
