### PR TITLE
style: apply ruff 0.16 markdown code-block formatting

### DIFF
--- a/lettucedetect/integrations/langchain/README.md
+++ b/lettucedetect/integrations/langchain/README.md
@@ -29,9 +29,7 @@ vectorstore = Chroma.from_documents(docs, embeddings)
 # Create streaming RAG chain
 llm = ChatOpenAI(model="gpt-4o-mini", streaming=True)
 chain = RetrievalQA.from_chain_type(
-    llm=llm,
-    chain_type="stuff",
-    retriever=vectorstore.as_retriever(search_kwargs={"k": 3})
+    llm=llm, chain_type="stuff", retriever=vectorstore.as_retriever(search_kwargs={"k": 3})
 )
 
 # Get context and stream with detection
@@ -59,7 +57,7 @@ callback = LettuceStreamingCallback(
     context=context,
     question=question,
     check_every=10,
-    method="transformer"  # or "rag_fact_checker"
+    method="transformer",  # or "rag_fact_checker"
 )
 
 # Use with any LangChain chain


### PR DESCRIPTION
## What

CI installs unpinned ruff; 0.16.0 (released today) began formatting code blocks inside markdown and fails `ruff format --check` on `lettucedetect/integrations/langchain/README.md`. This applies the one-file reformat, restoring green lint on main (the failure predates and is unrelated to the changes in the runs it first appeared on).

## Checklist

- [x] `ruff format --check` and `ruff check` pass locally with ruff 0.16.0.

- [x] I certify that I have the right to submit this code and that it may be distributed under the repository's MIT license