### PR TITLE
docs: mark shipped roadmap items (#85, #50)

### DIFF
--- a/PUBLIC_ROADMAP.md
+++ b/PUBLIC_ROADMAP.md
@@ -11,19 +11,17 @@ Open:
 - [Real batched inference](https://github.com/KRLabsOrg/LettuceDetect/issues/23): `predict_prompt_batch` currently loops one sample at a time; the plan is padded-batch tokenization with a single forward pass.
 - [Lighter installs](https://github.com/KRLabsOrg/LettuceDetect/issues/69): lazy top-level imports so the LLM detector never touches torch. How to slim the default install without breaking existing users is an open design question; input welcome on the issue.
 - [Define evidence aggregation for chunked inference](https://github.com/KRLabsOrg/LettuceDetect/issues/74): benchmark whether evidence in any chunk or every chunk is required before changing the current conservative behavior.
-- [Map repeated LLM span strings to distinct answer occurrences](https://github.com/KRLabsOrg/LettuceDetect/issues/85)
 
-Shipped in this milestone so far: the network-free unit suite as a merge gate ([#73](https://github.com/KRLabsOrg/LettuceDetect/issues/73)), the `lettucedetect` CLI ([#47](https://github.com/KRLabsOrg/LettuceDetect/issues/47)), the detector latency/throughput benchmark ([#58](https://github.com/KRLabsOrg/LettuceDetect/issues/58)), token output from the LLM detector ([#65](https://github.com/KRLabsOrg/LettuceDetect/issues/65)), and the `min_confidence` documentation ([#64](https://github.com/KRLabsOrg/LettuceDetect/issues/64)).
+Shipped in this milestone so far: the network-free unit suite as a merge gate ([#73](https://github.com/KRLabsOrg/LettuceDetect/issues/73)), the `lettucedetect` CLI ([#47](https://github.com/KRLabsOrg/LettuceDetect/issues/47)), the detector latency/throughput benchmark ([#58](https://github.com/KRLabsOrg/LettuceDetect/issues/58)), token output from the LLM detector ([#65](https://github.com/KRLabsOrg/LettuceDetect/issues/65)), the `min_confidence` documentation ([#64](https://github.com/KRLabsOrg/LettuceDetect/issues/64)), and deterministic localization of repeated LLM spans ([#85](https://github.com/KRLabsOrg/LettuceDetect/issues/85)).
 
 ## Next: [Validation — Typed-span workflows](https://github.com/KRLabsOrg/LettuceDetect/milestone/3)
 
 The detectors already emit typed spans (category and subcategory per detected span). This milestone tests whether that localization improves real debugging, evaluation, monitoring, and agent workflows.
 
 - [Dataset-level hallucination-rate evaluation and reporting](https://github.com/KRLabsOrg/LettuceDetect/issues/56)
-- [A Claude Code hook that flags hallucinations in agent answers](https://github.com/KRLabsOrg/LettuceDetect/issues/50)
 - [A stable HTTP contract for typed spans and detector selection](https://github.com/KRLabsOrg/LettuceDetect/issues/75)
 
-Shipped: typed spans in the Streamlit demo ([#57](https://github.com/KRLabsOrg/LettuceDetect/issues/57)).
+Shipped: typed spans in the Streamlit demo ([#57](https://github.com/KRLabsOrg/LettuceDetect/issues/57)) and the Claude Code Stop hook ([#50](https://github.com/KRLabsOrg/LettuceDetect/issues/50)).
 
 ## Exploring: [transferable span detection](https://github.com/KRLabsOrg/LettuceDetect/milestone/2)
 


### PR DESCRIPTION
Status-only roadmap refresh: items that shipped are marked as shipped. No direction changes.

- [x] I certify that I have the right to submit this code and that it may be distributed under the repository's license